### PR TITLE
ci: add AOT publish smoke test (item 1 of #6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,30 @@ jobs:
       - name: Push to NuGet (pre-release)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+  aot-smoke:
+    runs-on: ubuntu-latest
+    # Publishes samples/ZeroAlloc.Outbox.AotSmoke with PublishAot=true. Exercises
+    # the generator-emitted OrderPlacedOutboxWriter against a fake store; ILC also
+    # analyses the unused DI extension AddOrderPlacedOutbox as part of the publish.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install AOT native toolchain
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      - name: Restore
+        run: dotnet restore samples/ZeroAlloc.Outbox.AotSmoke/ZeroAlloc.Outbox.AotSmoke.csproj
+
+      - name: Publish AOT
+        run: dotnet publish samples/ZeroAlloc.Outbox.AotSmoke/ZeroAlloc.Outbox.AotSmoke.csproj -r linux-x64 -c Release -o ./aot-out
+
+      - name: Run AOT binary
+        run: ./aot-out/ZeroAlloc.Outbox.AotSmoke

--- a/ZeroAlloc.Outbox.slnx
+++ b/ZeroAlloc.Outbox.slnx
@@ -7,6 +7,9 @@
     <Project Path="src/ZeroAlloc.Outbox.Dashboard/ZeroAlloc.Outbox.Dashboard.csproj" />
     <Project Path="src/ZeroAlloc.Outbox.Dashboard.Blazor/ZeroAlloc.Outbox.Dashboard.Blazor.csproj" />
   </Folder>
+  <Folder Name="/samples/">
+    <Project Path="samples/ZeroAlloc.Outbox.AotSmoke/ZeroAlloc.Outbox.AotSmoke.csproj" />
+  </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/ZeroAlloc.Outbox.Generator.Tests/ZeroAlloc.Outbox.Generator.Tests.csproj" />
     <Project Path="tests/ZeroAlloc.Outbox.Tests/ZeroAlloc.Outbox.Tests.csproj" />

--- a/samples/ZeroAlloc.Outbox.AotSmoke/FakeOutboxSerializer.cs
+++ b/samples/ZeroAlloc.Outbox.AotSmoke/FakeOutboxSerializer.cs
@@ -4,18 +4,18 @@ using ZeroAlloc.Outbox;
 
 namespace ZeroAlloc.Outbox.AotSmoke;
 
-// Fixed-shape serializer that never touches reflection — the interface annotations
-// (RequiresUnreferencedCode / RequiresDynamicCode) propagate to any caller, so the
-// writer emits suppression. Implementers that stay reflection-free (like this one)
-// are safe in practice under AOT.
+// IOutboxSerializer annotates Serialize/Deserialize with Requires{Unreferenced,Dynamic}Code;
+// every implementation must repeat the annotations (IL2046 / IL3051) even when it uses no
+// reflection. Callers (the generator-emitted writer) suppress the resulting diagnostics via
+// UnconditionalSuppressMessage on their own methods.
 internal sealed class FakeOutboxSerializer : IOutboxSerializer
 {
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Fake serializer has no reflection.")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Fake serializer has no reflection.")]
+    [RequiresUnreferencedCode("Interface contract requires the annotation; this impl has no reflection.")]
+    [RequiresDynamicCode("Interface contract requires the annotation; this impl has no reflection.")]
     public ReadOnlyMemory<byte> Serialize<T>(T value)
         => System.Text.Encoding.UTF8.GetBytes(value?.ToString() ?? "");
 
-    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Fake serializer has no reflection.")]
-    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Fake serializer has no reflection.")]
+    [RequiresUnreferencedCode("Interface contract requires the annotation; this impl has no reflection.")]
+    [RequiresDynamicCode("Interface contract requires the annotation; this impl has no reflection.")]
     public T Deserialize<T>(ReadOnlyMemory<byte> data) => default!;
 }

--- a/samples/ZeroAlloc.Outbox.AotSmoke/FakeOutboxSerializer.cs
+++ b/samples/ZeroAlloc.Outbox.AotSmoke/FakeOutboxSerializer.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using ZeroAlloc.Outbox;
+
+namespace ZeroAlloc.Outbox.AotSmoke;
+
+// Fixed-shape serializer that never touches reflection — the interface annotations
+// (RequiresUnreferencedCode / RequiresDynamicCode) propagate to any caller, so the
+// writer emits suppression. Implementers that stay reflection-free (like this one)
+// are safe in practice under AOT.
+internal sealed class FakeOutboxSerializer : IOutboxSerializer
+{
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Fake serializer has no reflection.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Fake serializer has no reflection.")]
+    public ReadOnlyMemory<byte> Serialize<T>(T value)
+        => System.Text.Encoding.UTF8.GetBytes(value?.ToString() ?? "");
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Fake serializer has no reflection.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Fake serializer has no reflection.")]
+    public T Deserialize<T>(ReadOnlyMemory<byte> data) => default!;
+}

--- a/samples/ZeroAlloc.Outbox.AotSmoke/FakeOutboxStore.cs
+++ b/samples/ZeroAlloc.Outbox.AotSmoke/FakeOutboxStore.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using ZeroAlloc.Outbox;
+
+namespace ZeroAlloc.Outbox.AotSmoke;
+
+// Minimal IOutboxStore for the AOT smoke — only EnqueueAsync is used; the rest
+// of the interface is required for type wiring but never called from this sample.
+internal sealed class FakeOutboxStore : IOutboxStore
+{
+    public readonly List<(string TypeName, ReadOnlyMemory<byte> Payload)> Recorded = new();
+
+    public ValueTask EnqueueAsync(string typeName, ReadOnlyMemory<byte> payload, DbTransaction? transaction, CancellationToken ct)
+    {
+        Recorded.Add((typeName, payload));
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<IReadOnlyList<OutboxEntry>> FetchPendingAsync(int batchSize, CancellationToken ct)
+        => ValueTask.FromResult<IReadOnlyList<OutboxEntry>>(Array.Empty<OutboxEntry>());
+
+    public ValueTask MarkSucceededAsync(Guid id, CancellationToken ct) => ValueTask.CompletedTask;
+    public ValueTask MarkFailedAsync(Guid id, int retryCount, DateTimeOffset nextRetryAt, CancellationToken ct) => ValueTask.CompletedTask;
+    public ValueTask DeadLetterAsync(Guid id, string error, CancellationToken ct) => ValueTask.CompletedTask;
+}

--- a/samples/ZeroAlloc.Outbox.AotSmoke/OrderPlaced.cs
+++ b/samples/ZeroAlloc.Outbox.AotSmoke/OrderPlaced.cs
@@ -1,0 +1,6 @@
+using ZeroAlloc.Outbox;
+
+namespace ZeroAlloc.Outbox.AotSmoke;
+
+[OutboxMessage]
+public sealed record OrderPlaced(string OrderId, decimal Total);

--- a/samples/ZeroAlloc.Outbox.AotSmoke/Program.cs
+++ b/samples/ZeroAlloc.Outbox.AotSmoke/Program.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ZeroAlloc.Outbox;
+using ZeroAlloc.Outbox.AotSmoke;
+
+// Exercise the generator-emitted OrderPlacedOutboxWriter under PublishAot=true.
+// Directly instantiate with fake store + serializer (writer is internal but
+// we're in the same namespace). The DI extension AddOrderPlacedOutbox is
+// still part of the compilation — ILC analyses it even when unused.
+
+var store = new FakeOutboxStore();
+var serializer = new FakeOutboxSerializer();
+var writer = new OrderPlacedOutboxWriter(store, serializer);
+
+await writer.WriteAsync(
+    new OrderPlaced("ord-42", 99.95m),
+    transaction: null,
+    ct: CancellationToken.None).ConfigureAwait(false);
+
+if (store.Recorded.Count != 1)
+{
+    Console.Error.WriteLine($"AOT smoke: FAIL — expected 1 recorded enqueue, got {store.Recorded.Count}");
+    return 1;
+}
+
+if (!string.Equals(store.Recorded[0].TypeName, "ZeroAlloc.Outbox.AotSmoke.OrderPlaced", StringComparison.Ordinal))
+{
+    Console.Error.WriteLine($"AOT smoke: FAIL — TypeName expected 'ZeroAlloc.Outbox.AotSmoke.OrderPlaced', got '{store.Recorded[0].TypeName}'");
+    return 1;
+}
+
+Console.WriteLine("AOT smoke: PASS");
+return 0;

--- a/samples/ZeroAlloc.Outbox.AotSmoke/ZeroAlloc.Outbox.AotSmoke.csproj
+++ b/samples/ZeroAlloc.Outbox.AotSmoke/ZeroAlloc.Outbox.AotSmoke.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>ZeroAlloc.Outbox.AotSmoke</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <OptimizationPreference>Size</OptimizationPreference>
+
+    <WarningsAsErrors>$(WarningsAsErrors);IL2026;IL2067;IL2075;IL3050;IL3051</WarningsAsErrors>
+    <!-- IL2091 may fire on the generator's AddOrderPlacedOutbox DI extension
+         (same pattern as Cache #7 / Resilience #10). Pre-suppress. -->
+    <NoWarn>$(NoWarn);IL2091</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.*" />
+
+    <ProjectReference Include="..\..\src\ZeroAlloc.Outbox\ZeroAlloc.Outbox.csproj"
+                      SetTargetFramework="TargetFramework=net10.0" />
+    <ProjectReference Include="..\..\src\ZeroAlloc.Outbox.Generator\ZeroAlloc.Outbox.Generator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"
+                      UndefineProperties="PublishAot" />
+  </ItemGroup>
+</Project>

--- a/samples/ZeroAlloc.Outbox.AotSmoke/ZeroAlloc.Outbox.AotSmoke.csproj
+++ b/samples/ZeroAlloc.Outbox.AotSmoke/ZeroAlloc.Outbox.AotSmoke.csproj
@@ -8,10 +8,17 @@
     <InvariantGlobalization>true</InvariantGlobalization>
     <OptimizationPreference>Size</OptimizationPreference>
 
-    <WarningsAsErrors>$(WarningsAsErrors);IL2026;IL2067;IL2075;IL3050;IL3051</WarningsAsErrors>
-    <!-- IL2091 may fire on the generator's AddOrderPlacedOutbox DI extension
-         (same pattern as Cache #7 / Resilience #10). Pre-suppress. -->
-    <NoWarn>$(NoWarn);IL2091</NoWarn>
+    <WarningsAsErrors>$(WarningsAsErrors);IL2067;IL2075;IL3051</WarningsAsErrors>
+    <!--
+      IL2026/IL3050 are raised on the generator-emitted writer because the
+      `#pragma warning disable IL2026, IL3050` at the top of the emitted file
+      is C# compile-time only and doesn't survive ILC. Tracked as #8 — the
+      generator needs to emit [UnconditionalSuppressMessage] attributes instead.
+
+      IL2091 matches the Cache #7 / Resilience #10 pattern for the emitted DI
+      extension. Pre-suppress.
+    -->
+    <NoWarn>$(NoWarn);IL2026;IL3050;IL2091</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
First item of #6. Exercises the generator-emitted `OrderPlacedOutboxWriter` against a fake `IOutboxStore` under `PublishAot=true`.