### PR TITLE
feat(outbox): use ConcurrentHeapSpanDictionary for InMemoryOutboxStore

### DIFF
--- a/src/ZeroAlloc.Outbox.InMemory/InMemoryOutboxStore.cs
+++ b/src/ZeroAlloc.Outbox.InMemory/InMemoryOutboxStore.cs
@@ -1,7 +1,7 @@
-using System.Collections.Concurrent;
 using System.Data.Common;
 using System.Runtime.CompilerServices;
 using System.Text;
+using ZeroAlloc.Collections;
 
 namespace ZeroAlloc.Outbox.InMemory;
 
@@ -10,10 +10,10 @@ namespace ZeroAlloc.Outbox.InMemory;
 /// Not suitable for long-running production processes — throughput buckets accumulate
 /// indefinitely and there is no persistence across process restarts.
 /// </summary>
-public sealed class InMemoryOutboxStore : IOutboxStore, IOutboxDashboardStore
+public sealed class InMemoryOutboxStore : IOutboxStore, IOutboxDashboardStore, IDisposable
 {
-    private readonly ConcurrentDictionary<Guid, InMemoryOutboxEntry> _entries = new();
-    private readonly ConcurrentDictionary<DateTimeOffset, ThroughputAccumulator> _throughput = new();
+    private readonly ConcurrentHeapSpanDictionary<Guid, InMemoryOutboxEntry> _entries = new();
+    private readonly ConcurrentHeapSpanDictionary<DateTimeOffset, ThroughputAccumulator> _throughput = new();
 
     public ValueTask EnqueueAsync(
         string typeName,
@@ -102,7 +102,7 @@ public sealed class InMemoryOutboxStore : IOutboxStore, IOutboxDashboardStore
     }
 
     /// <summary>Exposes all entries for test assertions.</summary>
-    public IReadOnlyList<InMemoryOutboxEntry> AllEntries() => _entries.Values.ToList();
+    public IReadOnlyList<InMemoryOutboxEntry> AllEntries() => _entries.ToValuesArray();
 
     public ValueTask<OutboxSnapshot> GetSnapshotAsync(int dispatchedLimit, CancellationToken ct)
     {
@@ -111,7 +111,7 @@ public sealed class InMemoryOutboxStore : IOutboxStore, IOutboxDashboardStore
         var dead = new List<OutboxMessageView>();
         var dispatched = new List<OutboxMessageView>();
 
-        foreach (var e in _entries.Values)
+        foreach (var e in _entries.ToValuesArray())
         {
             var view = ToView(e);
             switch (e.Status)
@@ -210,6 +210,13 @@ public sealed class InMemoryOutboxStore : IOutboxStore, IOutboxDashboardStore
 
     private static DateTimeOffset TruncateToMinute(DateTimeOffset dto) =>
         new(dto.Year, dto.Month, dto.Day, dto.Hour, dto.Minute, 0, dto.Offset);
+
+    /// <summary>Returns the pooled bucket arrays. Tests typically rely on GC.</summary>
+    public void Dispose()
+    {
+        _entries.Dispose();
+        _throughput.Dispose();
+    }
 
     private static OutboxMessageView ToView(InMemoryOutboxEntry e)
     {

--- a/src/ZeroAlloc.Outbox.InMemory/ZeroAlloc.Outbox.InMemory.csproj
+++ b/src/ZeroAlloc.Outbox.InMemory/ZeroAlloc.Outbox.InMemory.csproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\ZeroAlloc.Outbox\ZeroAlloc.Outbox.csproj" />
+    <PackageReference Include="ZeroAlloc.Collections" Version="0.1.6" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #16.

## Summary

Replaces both `ConcurrentDictionary` instances in `InMemoryOutboxStore` with `ZeroAlloc.Collections.ConcurrentHeapSpanDictionary<TKey, TValue>` (shipped in [v0.1.6](https://www.nuget.org/packages/ZeroAlloc.Collections/0.1.6)) — fulfils integration matrix row 16.

## Changes

- `src/ZeroAlloc.Outbox.InMemory/ZeroAlloc.Outbox.InMemory.csproj` — add `<PackageReference Include="ZeroAlloc.Collections" Version="0.1.6" />`.
- `src/ZeroAlloc.Outbox.InMemory/InMemoryOutboxStore.cs`
  - `_entries`: `ConcurrentDictionary<Guid, InMemoryOutboxEntry>` → `ConcurrentHeapSpanDictionary<Guid, InMemoryOutboxEntry>`
  - `_throughput`: `ConcurrentDictionary<DateTimeOffset, ThroughputAccumulator>` → `ConcurrentHeapSpanDictionary<DateTimeOffset, ThroughputAccumulator>`
  - Class now `IDisposable`; `Dispose()` returns both pooled bucket arrays.
  - Two `.Values` call sites → `.ToValuesArray()` (LINQ-compatible).
  - `TryGetValue`, `TryRemove`, indexer, `foreach`, `ToArray`, `GetOrAdd(factory)` all drop in unchanged.

## Honest note on the benchmark AC

Issue mentions measurable Gen0 reduction on the write path. The outbox `_entries` is a long-lived singleton, so the one-time bucket allocation doesn't register. `_throughput` accumulates one bucket per minute, so Gen0 pressure from that dictionary is also modest in practice. The concrete wins are (a) pooled-bucket cleanup via `Dispose()`, and (b) ecosystem cohesion — the suite now dogfoods its own concurrent primitive.

## Test plan

- [x] `dotnet test ZeroAlloc.Outbox.slnx -c Release` — 79/79 green (72 core + 7 generator).
- [ ] CI `build` + `aot-smoke` + `lint-commits`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)