### PR TITLE
feat: telemetry, typed OutboxMessageId, Mediator/Resilience + NuGet isolation

### DIFF
--- a/benchmarks/ZeroAlloc.Outbox.Benchmarks/WriteAsyncBenchmark.cs
+++ b/benchmarks/ZeroAlloc.Outbox.Benchmarks/WriteAsyncBenchmark.cs
@@ -49,9 +49,9 @@ internal sealed class FakeStore : IOutboxStore
     }
     public ValueTask<IReadOnlyList<OutboxEntry>> FetchPendingAsync(int batchSize, CancellationToken ct)
         => ValueTask.FromResult<IReadOnlyList<OutboxEntry>>(Array.Empty<OutboxEntry>());
-    public ValueTask MarkSucceededAsync(Guid id, CancellationToken ct) => ValueTask.CompletedTask;
-    public ValueTask MarkFailedAsync(Guid id, int retryCount, DateTimeOffset nextRetryAt, CancellationToken ct) => ValueTask.CompletedTask;
-    public ValueTask DeadLetterAsync(Guid id, string error, CancellationToken ct) => ValueTask.CompletedTask;
+    public ValueTask MarkSucceededAsync(OutboxMessageId id, CancellationToken ct) => ValueTask.CompletedTask;
+    public ValueTask MarkFailedAsync(OutboxMessageId id, int retryCount, DateTimeOffset nextRetryAt, CancellationToken ct) => ValueTask.CompletedTask;
+    public ValueTask DeadLetterAsync(OutboxMessageId id, string error, CancellationToken ct) => ValueTask.CompletedTask;
 }
 
 internal sealed class FakeSerializer : IOutboxSerializer

--- a/samples/ZeroAlloc.Outbox.AotSmoke/FakeOutboxStore.cs
+++ b/samples/ZeroAlloc.Outbox.AotSmoke/FakeOutboxStore.cs
@@ -22,7 +22,7 @@ internal sealed class FakeOutboxStore : IOutboxStore
     public ValueTask<IReadOnlyList<OutboxEntry>> FetchPendingAsync(int batchSize, CancellationToken ct)
         => ValueTask.FromResult<IReadOnlyList<OutboxEntry>>(Array.Empty<OutboxEntry>());
 
-    public ValueTask MarkSucceededAsync(Guid id, CancellationToken ct) => ValueTask.CompletedTask;
-    public ValueTask MarkFailedAsync(Guid id, int retryCount, DateTimeOffset nextRetryAt, CancellationToken ct) => ValueTask.CompletedTask;
-    public ValueTask DeadLetterAsync(Guid id, string error, CancellationToken ct) => ValueTask.CompletedTask;
+    public ValueTask MarkSucceededAsync(OutboxMessageId id, CancellationToken ct) => ValueTask.CompletedTask;
+    public ValueTask MarkFailedAsync(OutboxMessageId id, int retryCount, DateTimeOffset nextRetryAt, CancellationToken ct) => ValueTask.CompletedTask;
+    public ValueTask DeadLetterAsync(OutboxMessageId id, string error, CancellationToken ct) => ValueTask.CompletedTask;
 }

--- a/src/ZeroAlloc.Outbox.Dashboard/OutboxDashboardEndpointRouteBuilderExtensions.cs
+++ b/src/ZeroAlloc.Outbox.Dashboard/OutboxDashboardEndpointRouteBuilderExtensions.cs
@@ -5,6 +5,11 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+// ZeroAlloc.Results namespace enters the transitive closure when ZeroAlloc.Resilience is referenced
+// (Outbox#20). Because this file lives in namespace ZeroAlloc.Outbox.Dashboard, C# parent-chain
+// name lookup finds the namespace ZeroAlloc.Results before the type Microsoft.AspNetCore.Http.Results.
+// All Results.* call sites are qualified with the global:: alias below to force the correct type.
+using HttpResults = global::Microsoft.AspNetCore.Http.Results;
 
 namespace ZeroAlloc.Outbox.Dashboard;
 
@@ -146,9 +151,9 @@ public static class OutboxDashboardEndpointRouteBuilderExtensions
 
     private static void MapWriteEndpoints(RouteGroupBuilder group)
     {
-        group.MapPost("/api/messages/{id:guid}/requeue", RequeueAsync);
-        group.MapPost("/api/messages/{id:guid}/cancel", CancelAsync);
-        group.MapPost("/api/messages/{id:guid}/force-dispatch", ForceDispatchAsync);
+        group.MapPost("/api/messages/{id}/requeue", RequeueAsync);
+        group.MapPost("/api/messages/{id}/cancel", CancelAsync);
+        group.MapPost("/api/messages/{id}/force-dispatch", ForceDispatchAsync);
     }
 
     private static async Task<IResult> GetSnapshotAsync(
@@ -157,7 +162,7 @@ public static class OutboxDashboardEndpointRouteBuilderExtensions
         CancellationToken ct)
     {
         var snapshot = await store.GetSnapshotAsync(dispatchedLimit ?? 100, ct).ConfigureAwait(false);
-        return Results.Ok(snapshot);
+        return HttpResults.Ok(snapshot);
     }
 
     private static async Task<IResult> GetThroughputAsync(
@@ -171,11 +176,11 @@ public static class OutboxDashboardEndpointRouteBuilderExtensions
         {
             points.Add(p);
         }
-        return Results.Ok(points);
+        return HttpResults.Ok(points);
     }
 
     private static async Task<IResult> RequeueAsync(
-        Guid id,
+        OutboxMessageId id,
         [FromServices] IOutboxDashboardStore store,
         [FromServices] IOutboxDashboardEventPublisher? publisher,
         CancellationToken ct)
@@ -186,15 +191,15 @@ public static class OutboxDashboardEndpointRouteBuilderExtensions
         }
         catch (InvalidOperationException ex)
         {
-            return Results.UnprocessableEntity(new { error = ex.Message });
+            return HttpResults.UnprocessableEntity(new { error = ex.Message });
         }
 
         await SafePublishAsync(publisher, new MessageRequeuedEvent(id, DateTimeOffset.UtcNow), ct).ConfigureAwait(false);
-        return Results.NoContent();
+        return HttpResults.NoContent();
     }
 
     private static async Task<IResult> CancelAsync(
-        Guid id,
+        OutboxMessageId id,
         [FromServices] IOutboxDashboardStore store,
         [FromServices] IOutboxDashboardEventPublisher? publisher,
         CancellationToken ct)
@@ -205,15 +210,15 @@ public static class OutboxDashboardEndpointRouteBuilderExtensions
         }
         catch (InvalidOperationException ex)
         {
-            return Results.UnprocessableEntity(new { error = ex.Message });
+            return HttpResults.UnprocessableEntity(new { error = ex.Message });
         }
 
         await SafePublishAsync(publisher, new MessageCancelledEvent(id), ct).ConfigureAwait(false);
-        return Results.NoContent();
+        return HttpResults.NoContent();
     }
 
     private static async Task<IResult> ForceDispatchAsync(
-        Guid id,
+        OutboxMessageId id,
         [FromServices] IOutboxDashboardStore store,
         CancellationToken ct)
     {
@@ -223,11 +228,11 @@ public static class OutboxDashboardEndpointRouteBuilderExtensions
         }
         catch (InvalidOperationException ex)
         {
-            return Results.UnprocessableEntity(new { error = ex.Message });
+            return HttpResults.UnprocessableEntity(new { error = ex.Message });
         }
 
         // No event — the worker publishes MessageDispatchedEvent once it picks the message up.
-        return Results.NoContent();
+        return HttpResults.NoContent();
     }
 
     private static async ValueTask SafePublishAsync(

--- a/src/ZeroAlloc.Outbox.EfCore/EfCoreOutboxStore.cs
+++ b/src/ZeroAlloc.Outbox.EfCore/EfCoreOutboxStore.cs
@@ -54,7 +54,7 @@ public sealed class EfCoreOutboxStore<TContext> : IOutboxStore, IOutboxDashboard
         {
             result.Add(new OutboxEntry
             {
-                Id = row.Id,
+                Id = new OutboxMessageId(row.Id),
                 TypeName = row.TypeName,
                 RawPayload = row.Payload,
                 RetryCount = row.RetryCount,
@@ -64,20 +64,20 @@ public sealed class EfCoreOutboxStore<TContext> : IOutboxStore, IOutboxDashboard
         return result;
     }
 
-    public async ValueTask MarkSucceededAsync(Guid id, CancellationToken ct)
+    public async ValueTask MarkSucceededAsync(OutboxMessageId id, CancellationToken ct)
     {
         var entity = await _db.Set<OutboxMessageEntity>()
-            .FindAsync(new object[] { id }, ct).ConfigureAwait(false);
+            .FindAsync(new object[] { id.Value }, ct).ConfigureAwait(false);
         if (entity is null) return;
         entity.Status = OutboxMessageStatus.Succeeded;
         entity.ProcessedAt = DateTimeOffset.UtcNow;
         await _db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
 
-    public async ValueTask MarkFailedAsync(Guid id, int retryCount, DateTimeOffset nextRetryAt, CancellationToken ct)
+    public async ValueTask MarkFailedAsync(OutboxMessageId id, int retryCount, DateTimeOffset nextRetryAt, CancellationToken ct)
     {
         var entity = await _db.Set<OutboxMessageEntity>()
-            .FindAsync(new object[] { id }, ct).ConfigureAwait(false);
+            .FindAsync(new object[] { id.Value }, ct).ConfigureAwait(false);
         if (entity is null) return;
         entity.Status = OutboxMessageStatus.Pending;
         entity.RetryCount = retryCount;
@@ -85,10 +85,10 @@ public sealed class EfCoreOutboxStore<TContext> : IOutboxStore, IOutboxDashboard
         await _db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
 
-    public async ValueTask DeadLetterAsync(Guid id, string error, CancellationToken ct)
+    public async ValueTask DeadLetterAsync(OutboxMessageId id, string error, CancellationToken ct)
     {
         var entity = await _db.Set<OutboxMessageEntity>()
-            .FindAsync(new object[] { id }, ct).ConfigureAwait(false);
+            .FindAsync(new object[] { id.Value }, ct).ConfigureAwait(false);
         if (entity is null) return;
         entity.Status = OutboxMessageStatus.DeadLetter;
         entity.DeadLetterError = error;
@@ -229,10 +229,10 @@ public sealed class EfCoreOutboxStore<TContext> : IOutboxStore, IOutboxDashboard
         }
     }
 
-    public async ValueTask RequeueAsync(Guid id, CancellationToken ct)
+    public async ValueTask RequeueAsync(OutboxMessageId id, CancellationToken ct)
     {
         var entity = await _db.Set<OutboxMessageEntity>()
-            .FindAsync(new object[] { id }, ct).ConfigureAwait(false)
+            .FindAsync(new object[] { id.Value }, ct).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"Message {id} not found.");
         if (entity.Status != OutboxMessageStatus.DeadLetter)
             throw new InvalidOperationException($"Message {id} is not dead-lettered.");
@@ -244,10 +244,10 @@ public sealed class EfCoreOutboxStore<TContext> : IOutboxStore, IOutboxDashboard
         await _db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
 
-    public async ValueTask CancelAsync(Guid id, CancellationToken ct)
+    public async ValueTask CancelAsync(OutboxMessageId id, CancellationToken ct)
     {
         var entity = await _db.Set<OutboxMessageEntity>()
-            .FindAsync(new object[] { id }, ct).ConfigureAwait(false)
+            .FindAsync(new object[] { id.Value }, ct).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"Message {id} not found.");
         if (entity.Status != OutboxMessageStatus.Pending)
             throw new InvalidOperationException($"Message {id} cannot be cancelled (status: {entity.Status}).");
@@ -255,10 +255,10 @@ public sealed class EfCoreOutboxStore<TContext> : IOutboxStore, IOutboxDashboard
         await _db.SaveChangesAsync(ct).ConfigureAwait(false);
     }
 
-    public async ValueTask ForceDispatchAsync(Guid id, CancellationToken ct)
+    public async ValueTask ForceDispatchAsync(OutboxMessageId id, CancellationToken ct)
     {
         var entity = await _db.Set<OutboxMessageEntity>()
-            .FindAsync(new object[] { id }, ct).ConfigureAwait(false)
+            .FindAsync(new object[] { id.Value }, ct).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"Message {id} not found.");
         if (entity.Status != OutboxMessageStatus.Pending)
             throw new InvalidOperationException($"Message {id} is not pending (status: {entity.Status}).");
@@ -271,7 +271,7 @@ public sealed class EfCoreOutboxStore<TContext> : IOutboxStore, IOutboxDashboard
 
     private static OutboxMessageView ToView(in RawProjection r) => new()
     {
-        Id = r.Id,
+        Id = new OutboxMessageId(r.Id),
         TypeName = r.TypeName,
         CreatedAt = r.CreatedAt,
         RetryCount = r.RetryCount,

--- a/src/ZeroAlloc.Outbox.InMemory/InMemoryOutboxStore.cs
+++ b/src/ZeroAlloc.Outbox.InMemory/InMemoryOutboxStore.cs
@@ -10,9 +10,14 @@ namespace ZeroAlloc.Outbox.InMemory;
 /// Not suitable for long-running production processes — throughput buckets accumulate
 /// indefinitely and there is no persistence across process restarts.
 /// </summary>
+/// <remarks>
+/// Implements <see cref="IDisposable"/>: call <see cref="Dispose"/> when the store is no
+/// longer needed so the pooled backing arrays are returned to <see cref="System.Buffers.ArrayPool{T}"/>.
+/// The DI container disposes singleton registrations automatically on host shutdown.
+/// </remarks>
 public sealed class InMemoryOutboxStore : IOutboxStore, IOutboxDashboardStore, IDisposable
 {
-    private readonly ConcurrentHeapSpanDictionary<Guid, InMemoryOutboxEntry> _entries = new();
+    private readonly ConcurrentHeapSpanDictionary<OutboxMessageId, InMemoryOutboxEntry> _entries = new();
     private readonly ConcurrentHeapSpanDictionary<DateTimeOffset, ThroughputAccumulator> _throughput = new();
 
     public ValueTask EnqueueAsync(
@@ -23,7 +28,7 @@ public sealed class InMemoryOutboxStore : IOutboxStore, IOutboxDashboardStore, I
     {
         var entry = new InMemoryOutboxEntry
         {
-            Id = Guid.NewGuid(),
+            Id = OutboxMessageId.New(),
             TypeName = typeName,
             Payload = payload.ToArray(),
             RetryCount = 0,
@@ -58,7 +63,7 @@ public sealed class InMemoryOutboxStore : IOutboxStore, IOutboxDashboardStore, I
         return ValueTask.FromResult<IReadOnlyList<OutboxEntry>>(results);
     }
 
-    public ValueTask MarkSucceededAsync(Guid id, CancellationToken ct)
+    public ValueTask MarkSucceededAsync(OutboxMessageId id, CancellationToken ct)
     {
         if (_entries.TryGetValue(id, out var entry))
         {
@@ -72,7 +77,7 @@ public sealed class InMemoryOutboxStore : IOutboxStore, IOutboxDashboardStore, I
         return ValueTask.CompletedTask;
     }
 
-    public ValueTask MarkFailedAsync(Guid id, int retryCount, DateTimeOffset nextRetryAt, CancellationToken ct)
+    public ValueTask MarkFailedAsync(OutboxMessageId id, int retryCount, DateTimeOffset nextRetryAt, CancellationToken ct)
     {
         if (_entries.TryGetValue(id, out var entry))
         {
@@ -87,7 +92,7 @@ public sealed class InMemoryOutboxStore : IOutboxStore, IOutboxDashboardStore, I
         return ValueTask.CompletedTask;
     }
 
-    public ValueTask DeadLetterAsync(Guid id, string error, CancellationToken ct)
+    public ValueTask DeadLetterAsync(OutboxMessageId id, string error, CancellationToken ct)
     {
         if (_entries.TryGetValue(id, out var entry))
         {
@@ -102,7 +107,8 @@ public sealed class InMemoryOutboxStore : IOutboxStore, IOutboxDashboardStore, I
     }
 
     /// <summary>Exposes all entries for test assertions.</summary>
-    public IReadOnlyList<InMemoryOutboxEntry> AllEntries() => _entries.ToValuesArray();
+    public IReadOnlyList<InMemoryOutboxEntry> AllEntries() =>
+        _entries.Select(kv => kv.Value).ToList();
 
     public ValueTask<OutboxSnapshot> GetSnapshotAsync(int dispatchedLimit, CancellationToken ct)
     {
@@ -111,8 +117,9 @@ public sealed class InMemoryOutboxStore : IOutboxStore, IOutboxDashboardStore, I
         var dead = new List<OutboxMessageView>();
         var dispatched = new List<OutboxMessageView>();
 
-        foreach (var e in _entries.ToValuesArray())
+        foreach (var kv in _entries)
         {
+            var e = kv.Value;
             var view = ToView(e);
             switch (e.Status)
             {
@@ -156,7 +163,7 @@ public sealed class InMemoryOutboxStore : IOutboxStore, IOutboxDashboardStore, I
         }
     }
 
-    public ValueTask RequeueAsync(Guid id, CancellationToken ct)
+    public ValueTask RequeueAsync(OutboxMessageId id, CancellationToken ct)
     {
         if (!_entries.TryGetValue(id, out var entry))
             throw new InvalidOperationException($"Message {id} not found.");
@@ -172,7 +179,7 @@ public sealed class InMemoryOutboxStore : IOutboxStore, IOutboxDashboardStore, I
         return ValueTask.CompletedTask;
     }
 
-    public ValueTask CancelAsync(Guid id, CancellationToken ct)
+    public ValueTask CancelAsync(OutboxMessageId id, CancellationToken ct)
     {
         if (!_entries.TryGetValue(id, out var entry))
             throw new InvalidOperationException($"Message {id} not found.");
@@ -185,7 +192,7 @@ public sealed class InMemoryOutboxStore : IOutboxStore, IOutboxDashboardStore, I
         return ValueTask.CompletedTask;
     }
 
-    public ValueTask ForceDispatchAsync(Guid id, CancellationToken ct)
+    public ValueTask ForceDispatchAsync(OutboxMessageId id, CancellationToken ct)
     {
         if (!_entries.TryGetValue(id, out var entry))
             throw new InvalidOperationException($"Message {id} not found.");
@@ -210,13 +217,6 @@ public sealed class InMemoryOutboxStore : IOutboxStore, IOutboxDashboardStore, I
 
     private static DateTimeOffset TruncateToMinute(DateTimeOffset dto) =>
         new(dto.Year, dto.Month, dto.Day, dto.Hour, dto.Minute, 0, dto.Offset);
-
-    /// <summary>Returns the pooled bucket arrays. Tests typically rely on GC.</summary>
-    public void Dispose()
-    {
-        _entries.Dispose();
-        _throughput.Dispose();
-    }
 
     private static OutboxMessageView ToView(InMemoryOutboxEntry e)
     {
@@ -251,11 +251,21 @@ public sealed class InMemoryOutboxStore : IOutboxStore, IOutboxDashboardStore, I
     private static string DecodePreview(byte[] payload) =>
         Encoding.UTF8.GetString(payload, 0, Math.Min(payload.Length, 200));
 
+    /// <summary>
+    /// Returns the pooled backing arrays of both dictionaries to
+    /// <see cref="System.Buffers.ArrayPool{T}"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        _entries.Dispose();
+        _throughput.Dispose();
+    }
+
     public enum InMemoryEntryStatus { Pending, Succeeded, DeadLetter }
 
     public sealed class InMemoryOutboxEntry
     {
-        public Guid Id { get; init; }
+        public OutboxMessageId Id { get; init; }
         public required string TypeName { get; init; }
         public required byte[] Payload { get; set; }
         public int RetryCount { get; set; }

--- a/src/ZeroAlloc.Outbox/IOutboxDashboardStore.cs
+++ b/src/ZeroAlloc.Outbox/IOutboxDashboardStore.cs
@@ -22,7 +22,7 @@ public interface IOutboxDashboardStore
     /// </summary>
     /// <param name="id">The identifier of the message to requeue.</param>
     /// <param name="ct">Token to cancel the asynchronous operation.</param>
-    ValueTask RequeueAsync(Guid id, CancellationToken ct);
+    ValueTask RequeueAsync(OutboxMessageId id, CancellationToken ct);
 
     /// <summary>
     /// Removes a pending or retry-queue message. Throws
@@ -30,7 +30,7 @@ public interface IOutboxDashboardStore
     /// </summary>
     /// <param name="id">The identifier of the message to cancel.</param>
     /// <param name="ct">Token to cancel the asynchronous operation.</param>
-    ValueTask CancelAsync(Guid id, CancellationToken ct);
+    ValueTask CancelAsync(OutboxMessageId id, CancellationToken ct);
 
     /// <summary>
     /// Sets <c>NextRetryAt</c> to now so the next polling cycle picks up the message.
@@ -38,5 +38,5 @@ public interface IOutboxDashboardStore
     /// </summary>
     /// <param name="id">The identifier of the message to force-dispatch.</param>
     /// <param name="ct">Token to cancel the asynchronous operation.</param>
-    ValueTask ForceDispatchAsync(Guid id, CancellationToken ct);
+    ValueTask ForceDispatchAsync(OutboxMessageId id, CancellationToken ct);
 }

--- a/src/ZeroAlloc.Outbox/IOutboxStore.cs
+++ b/src/ZeroAlloc.Outbox/IOutboxStore.cs
@@ -16,11 +16,11 @@ public interface IOutboxStore
     ValueTask<IReadOnlyList<OutboxEntry>> FetchPendingAsync(int batchSize, CancellationToken ct);
 
     /// <summary>Marks a message as successfully dispatched.</summary>
-    ValueTask MarkSucceededAsync(Guid id, CancellationToken ct);
+    ValueTask MarkSucceededAsync(OutboxMessageId id, CancellationToken ct);
 
     /// <summary>Records a failed dispatch attempt and schedules the next retry.</summary>
-    ValueTask MarkFailedAsync(Guid id, int retryCount, DateTimeOffset nextRetryAt, CancellationToken ct);
+    ValueTask MarkFailedAsync(OutboxMessageId id, int retryCount, DateTimeOffset nextRetryAt, CancellationToken ct);
 
     /// <summary>Moves a message to dead-letter after exhausting all retry attempts.</summary>
-    ValueTask DeadLetterAsync(Guid id, string error, CancellationToken ct);
+    ValueTask DeadLetterAsync(OutboxMessageId id, string error, CancellationToken ct);
 }

--- a/src/ZeroAlloc.Outbox/IOutboxTypeDispatcher.cs
+++ b/src/ZeroAlloc.Outbox/IOutboxTypeDispatcher.cs
@@ -1,14 +1,40 @@
+using ZeroAlloc.Resilience;
+
 namespace ZeroAlloc.Outbox;
 
 /// <summary>
 /// Implemented by the source generator per [OutboxMessage] type and registered with DI.
 /// The background worker resolves all registered implementations to build a dispatch registry.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="DispatchAsync"/> is annotated with <see cref="RetryAttribute"/> so the Resilience
+/// generator can emit a proxy for any custom single-implementation scenario.
+/// </para>
+/// <para>
+/// <b>Architectural note (Outbox#20):</b> The Resilience proxy cannot replace the
+/// <c>IEnumerable&lt;IOutboxTypeDispatcher&gt;</c> collection pattern used by
+/// <c>OutboxWorkerService</c> because the generated
+/// <c>AddIOutboxTypeDispatcherResilience&lt;TImpl&gt;</c> extension wraps a single
+/// implementation and cannot interpose each element of the collection individually.
+/// Full proxy-based DI replacement is deferred. The store-level exponential backoff
+/// (<c>MarkFailedAsync</c> / <c>nextRetry</c>) is a durable cross-poll schedule and
+/// is likewise deferred — it is not replaceable by an in-process <c>[Retry]</c> loop
+/// without a redesign.
+/// </para>
+/// </remarks>
 public interface IOutboxTypeDispatcher
 {
     /// <summary>The fully-qualified type name used as the discriminator in the store.</summary>
     string TypeName { get; }
 
     /// <summary>Deserializes <paramref name="payload"/> and dispatches the message.</summary>
+    /// <remarks>
+    /// Annotated with <see cref="RetryAttribute"/> so the Resilience generator produces a proxy
+    /// for single-implementation wrappers. Default: 3 attempts, 200 ms exponential backoff.
+    /// The <c>IEnumerable&lt;IOutboxTypeDispatcher&gt;</c> collection registration in
+    /// <c>OutboxWorkerService</c> is not automatically wrapped — see class-level remarks.
+    /// </remarks>
+    [Retry(MaxAttempts = 3, BackoffMs = 200)]
     ValueTask DispatchAsync(ReadOnlyMemory<byte> payload, CancellationToken ct);
 }

--- a/src/ZeroAlloc.Outbox/MessageCancelledEvent.cs
+++ b/src/ZeroAlloc.Outbox/MessageCancelledEvent.cs
@@ -1,4 +1,4 @@
 namespace ZeroAlloc.Outbox;
 
 /// <summary>Raised when a pending/retry message is cancelled from the dashboard.</summary>
-public sealed record MessageCancelledEvent(Guid Id) : OutboxDashboardEvent(Id);
+public sealed record MessageCancelledEvent(OutboxMessageId Id) : OutboxDashboardEvent(Id);

--- a/src/ZeroAlloc.Outbox/MessageDeadLetteredEvent.cs
+++ b/src/ZeroAlloc.Outbox/MessageDeadLetteredEvent.cs
@@ -1,4 +1,4 @@
 namespace ZeroAlloc.Outbox;
 
 /// <summary>Raised when a message is dead-lettered after exhausting all attempts.</summary>
-public sealed record MessageDeadLetteredEvent(Guid Id, string Error, int TotalAttempts) : OutboxDashboardEvent(Id);
+public sealed record MessageDeadLetteredEvent(OutboxMessageId Id, string Error, int TotalAttempts) : OutboxDashboardEvent(Id);

--- a/src/ZeroAlloc.Outbox/MessageDispatchedEvent.cs
+++ b/src/ZeroAlloc.Outbox/MessageDispatchedEvent.cs
@@ -1,4 +1,4 @@
 namespace ZeroAlloc.Outbox;
 
 /// <summary>Raised when a message is dispatched successfully.</summary>
-public sealed record MessageDispatchedEvent(Guid Id, DateTimeOffset DispatchedAt, int AttemptCount) : OutboxDashboardEvent(Id);
+public sealed record MessageDispatchedEvent(OutboxMessageId Id, DateTimeOffset DispatchedAt, int AttemptCount) : OutboxDashboardEvent(Id);

--- a/src/ZeroAlloc.Outbox/MessageFailedEvent.cs
+++ b/src/ZeroAlloc.Outbox/MessageFailedEvent.cs
@@ -1,4 +1,4 @@
 namespace ZeroAlloc.Outbox;
 
 /// <summary>Raised when a dispatch attempt fails but more attempts remain.</summary>
-public sealed record MessageFailedEvent(Guid Id, string Error, int AttemptCount, DateTimeOffset NextRetryAt) : OutboxDashboardEvent(Id);
+public sealed record MessageFailedEvent(OutboxMessageId Id, string Error, int AttemptCount, DateTimeOffset NextRetryAt) : OutboxDashboardEvent(Id);

--- a/src/ZeroAlloc.Outbox/MessageQueuedEvent.cs
+++ b/src/ZeroAlloc.Outbox/MessageQueuedEvent.cs
@@ -1,4 +1,4 @@
 namespace ZeroAlloc.Outbox;
 
 /// <summary>Raised when a new message is queued to the outbox.</summary>
-public sealed record MessageQueuedEvent(Guid Id, string TypeName, DateTimeOffset QueuedAt) : OutboxDashboardEvent(Id);
+public sealed record MessageQueuedEvent(OutboxMessageId Id, string TypeName, DateTimeOffset QueuedAt) : OutboxDashboardEvent(Id);

--- a/src/ZeroAlloc.Outbox/MessageRequeuedEvent.cs
+++ b/src/ZeroAlloc.Outbox/MessageRequeuedEvent.cs
@@ -1,4 +1,4 @@
 namespace ZeroAlloc.Outbox;
 
 /// <summary>Raised when a dead-lettered message is requeued from the dashboard.</summary>
-public sealed record MessageRequeuedEvent(Guid Id, DateTimeOffset RequeuedAt) : OutboxDashboardEvent(Id);
+public sealed record MessageRequeuedEvent(OutboxMessageId Id, DateTimeOffset RequeuedAt) : OutboxDashboardEvent(Id);

--- a/src/ZeroAlloc.Outbox/OutboxDashboardEvent.cs
+++ b/src/ZeroAlloc.Outbox/OutboxDashboardEvent.cs
@@ -1,4 +1,4 @@
 namespace ZeroAlloc.Outbox;
 
 /// <summary>Base type for events pushed over the dashboard SSE stream.</summary>
-public abstract record OutboxDashboardEvent(Guid Id);
+public abstract record OutboxDashboardEvent(OutboxMessageId Id);

--- a/src/ZeroAlloc.Outbox/OutboxEntry.cs
+++ b/src/ZeroAlloc.Outbox/OutboxEntry.cs
@@ -3,7 +3,7 @@ namespace ZeroAlloc.Outbox;
 /// <summary>A pending outbox message fetched from the store for dispatch.</summary>
 public sealed class OutboxEntry
 {
-    public required Guid Id { get; init; }
+    public required OutboxMessageId Id { get; init; }
     public required string TypeName { get; init; }
     public required byte[] RawPayload { get; init; }
     public ReadOnlyMemory<byte> Payload => RawPayload;

--- a/src/ZeroAlloc.Outbox/OutboxMessageId.cs
+++ b/src/ZeroAlloc.Outbox/OutboxMessageId.cs
@@ -1,0 +1,6 @@
+using ZeroAlloc.ValueObjects;
+
+namespace ZeroAlloc.Outbox;
+
+[TypedId]
+public readonly partial record struct OutboxMessageId;

--- a/src/ZeroAlloc.Outbox/OutboxMessageView.cs
+++ b/src/ZeroAlloc.Outbox/OutboxMessageView.cs
@@ -3,7 +3,7 @@ namespace ZeroAlloc.Outbox;
 /// <summary>Read-only projection of an outbox message for the dashboard.</summary>
 public sealed record OutboxMessageView
 {
-    public required Guid Id { get; init; }
+    public required OutboxMessageId Id { get; init; }
     public required string TypeName { get; init; }
     public required DateTimeOffset CreatedAt { get; init; }
     public required int RetryCount { get; init; }

--- a/src/ZeroAlloc.Outbox/OutboxWorkerService.cs
+++ b/src/ZeroAlloc.Outbox/OutboxWorkerService.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -12,6 +14,13 @@ namespace ZeroAlloc.Outbox;
 /// </summary>
 public sealed class OutboxWorkerService : BackgroundService
 {
+    private static readonly ActivitySource _activitySource = new("ZeroAlloc.Outbox");
+    private static readonly Meter _meter = new("ZeroAlloc.Outbox");
+    private static readonly Counter<long> _dispatchAttempts = _meter.CreateCounter<long>("outbox.dispatch_attempts");
+    private static readonly Counter<long> _retries = _meter.CreateCounter<long>("outbox.retries");
+    private static readonly Counter<long> _deadLetters = _meter.CreateCounter<long>("outbox.dead_letters");
+    private static readonly Histogram<double> _dispatchDurationMs = _meter.CreateHistogram<double>("outbox.dispatch_duration_ms");
+
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly OutboxOptions _options;
     private readonly ILogger<OutboxWorkerService> _logger;
@@ -82,14 +91,24 @@ public sealed class OutboxWorkerService : BackgroundService
     {
         if (!dispatchers.TryGetValue(entry.TypeName, out var dispatcher))
         {
+            var deadTag = new TagList { { "message.type", entry.TypeName } };
+            _deadLetters.Add(1, deadTag);
             await DeadLetterMissingDispatcherAsync(store, publisher, entry, ct).ConfigureAwait(false);
             return;
         }
+
+        using var activity = _activitySource.StartActivity("outbox.dispatch");
+        activity?.SetTag("message.type", entry.TypeName);
+        var startTimestamp = Stopwatch.GetTimestamp();
+        var tag = new TagList { { "message.type", entry.TypeName } };
 
         try
         {
             await dispatcher.DispatchAsync(entry.Payload, ct).ConfigureAwait(false);
             await store.MarkSucceededAsync(entry.Id, ct).ConfigureAwait(false);
+
+            _dispatchAttempts.Add(1, tag);
+            activity?.SetStatus(ActivityStatusCode.Ok);
 
             await SafePublishAsync(
                 publisher,
@@ -100,7 +119,12 @@ public sealed class OutboxWorkerService : BackgroundService
         catch (Exception ex) when (ex is not OperationCanceledException)
 #pragma warning restore CA1031
         {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             await HandleDispatchFailureAsync(store, publisher, entry, ex, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _dispatchDurationMs.Record(Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds, tag);
         }
     }
 
@@ -155,6 +179,7 @@ public sealed class OutboxWorkerService : BackgroundService
             _logger.LogError(ex,
                 "Message {Id} ({TypeName}) exhausted {MaxAttempts} attempts. Dead-lettering.",
                 entry.Id, entry.TypeName, _options.MaxAttempts);
+            _deadLetters.Add(1, new TagList { { "message.type", entry.TypeName } });
             await store.DeadLetterAsync(entry.Id, ex.Message, ct).ConfigureAwait(false);
 
             await SafePublishAsync(
@@ -172,6 +197,7 @@ public sealed class OutboxWorkerService : BackgroundService
         _logger.LogWarning(ex,
             "Message {Id} ({TypeName}) failed (attempt {Attempt}/{Max}). Retry at {NextRetry}.",
             entry.Id, entry.TypeName, newRetryCount, _options.MaxAttempts, nextRetry);
+        _retries.Add(1, new TagList { { "message.type", entry.TypeName } });
 
         await store.MarkFailedAsync(entry.Id, newRetryCount, nextRetry, ct).ConfigureAwait(false);
 

--- a/src/ZeroAlloc.Outbox/ZeroAlloc.Outbox.csproj
+++ b/src/ZeroAlloc.Outbox/ZeroAlloc.Outbox.csproj
@@ -19,5 +19,8 @@
       OutputItemType="Analyzer"
       ReferenceOutputAssembly="false"
       PrivateAssets="all" />
+    <PackageReference Include="ZeroAlloc.ValueObjects" Version="1.2.0" />
+    <PackageReference Include="ZeroAlloc.Mediator" Version="1.1.8" />
+    <PackageReference Include="ZeroAlloc.Resilience" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/tests/ZeroAlloc.Outbox.Tests/DashboardEventPublisherTests.cs
+++ b/tests/ZeroAlloc.Outbox.Tests/DashboardEventPublisherTests.cs
@@ -9,7 +9,7 @@ public class DashboardEventPublisherTests
     {
         var pub = new ChannelOutboxDashboardEventPublisher();
         using var sub = pub.Subscribe();
-        var evt = new MessageDispatchedEvent(Guid.NewGuid(), DateTimeOffset.UtcNow, 1);
+        var evt = new MessageDispatchedEvent(OutboxMessageId.New(), DateTimeOffset.UtcNow, 1);
 
         await pub.PublishAsync(evt, CancellationToken.None);
 
@@ -23,7 +23,7 @@ public class DashboardEventPublisherTests
         var pub = new ChannelOutboxDashboardEventPublisher();
         using var s1 = pub.Subscribe();
         using var s2 = pub.Subscribe();
-        var evt = new MessageCancelledEvent(Guid.NewGuid());
+        var evt = new MessageCancelledEvent(OutboxMessageId.New());
 
         await pub.PublishAsync(evt, CancellationToken.None);
 
@@ -53,8 +53,8 @@ public class DashboardEventPublisherTests
         using var slow = pub.Subscribe();   // never reads
         using var fast = pub.Subscribe();
 
-        var evt1 = new MessageCancelledEvent(Guid.NewGuid());
-        var evt2 = new MessageCancelledEvent(Guid.NewGuid());
+        var evt1 = new MessageCancelledEvent(OutboxMessageId.New());
+        var evt2 = new MessageCancelledEvent(OutboxMessageId.New());
 
         await pub.PublishAsync(evt1, CancellationToken.None);
         await pub.PublishAsync(evt2, CancellationToken.None);
@@ -75,7 +75,7 @@ public class DashboardEventPublisherTests
 
         // Default capacity is 256. Push 300 to force 44 drops.
         for (int i = 0; i < 300; i++)
-            await pub.PublishAsync(new MessageDispatchedEvent(Guid.NewGuid(), DateTimeOffset.UtcNow, i), CancellationToken.None);
+            await pub.PublishAsync(new MessageDispatchedEvent(OutboxMessageId.New(), DateTimeOffset.UtcNow, i), CancellationToken.None);
 
         // Drain what remains; should be exactly 256 (capacity), with the oldest 44 dropped.
         var drained = new List<OutboxDashboardEvent>();
@@ -97,7 +97,7 @@ public class DashboardEventPublisherTests
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        var evt = new MessageCancelledEvent(Guid.NewGuid());
+        var evt = new MessageCancelledEvent(OutboxMessageId.New());
         await Assert.ThrowsAsync<OperationCanceledException>(
             async () => await pub.PublishAsync(evt, cts.Token).ConfigureAwait(false));
     }

--- a/tests/ZeroAlloc.Outbox.Tests/DashboardHtmlTests.cs
+++ b/tests/ZeroAlloc.Outbox.Tests/DashboardHtmlTests.cs
@@ -13,7 +13,7 @@ public sealed class DashboardHtmlTests
     [Fact]
     public async Task Root_Returns_HtmlPage_WithBasePathSubstituted()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         using var host = await CreateHostAsync(store);
         var client = host.GetTestClient();
 
@@ -30,7 +30,7 @@ public sealed class DashboardHtmlTests
     [Fact]
     public async Task Root_Uses_NonDefaultBasePath_InBaseHref()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         using var host = await CreateHostAsync(store, "/admin/ops");
         var client = host.GetTestClient();
 
@@ -45,7 +45,7 @@ public sealed class DashboardHtmlTests
     [Fact]
     public async Task Css_Returns_TextCss()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         using var host = await CreateHostAsync(store);
         var client = host.GetTestClient();
 
@@ -58,7 +58,7 @@ public sealed class DashboardHtmlTests
     [Fact]
     public async Task Js_Returns_ApplicationJavascript()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         using var host = await CreateHostAsync(store);
         var client = host.GetTestClient();
 

--- a/tests/ZeroAlloc.Outbox.Tests/DashboardRestEndpointsTests.cs
+++ b/tests/ZeroAlloc.Outbox.Tests/DashboardRestEndpointsTests.cs
@@ -39,7 +39,7 @@ public sealed class DashboardRestEndpointsTests
     [Fact]
     public async Task Snapshot_Returns200_WithExpectedShape()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         await store.EnqueueAsync("T1", new byte[] { 1 }, null, CancellationToken.None);
 
         var (host, client) = await CreateClientAsync(store);
@@ -59,7 +59,7 @@ public sealed class DashboardRestEndpointsTests
     [Fact]
     public async Task Throughput_Returns200_WithEmptyArray_WhenNoDispatch()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
 
         var (host, client) = await CreateClientAsync(store);
         using (host)
@@ -77,7 +77,7 @@ public sealed class DashboardRestEndpointsTests
     [Fact]
     public async Task Requeue_Returns204_ForDeadLetteredMessage()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         await store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
         var id = store.AllEntries()[0].Id;
         await store.MarkFailedAsync(id, 3, DateTimeOffset.UtcNow, CancellationToken.None);
@@ -97,7 +97,7 @@ public sealed class DashboardRestEndpointsTests
     [Fact]
     public async Task Requeue_Returns422_ForPendingMessage()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         await store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
         var id = store.AllEntries()[0].Id;
 
@@ -115,7 +115,7 @@ public sealed class DashboardRestEndpointsTests
     [Fact]
     public async Task Cancel_Returns204_ForPendingMessage()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         await store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
         var id = store.AllEntries()[0].Id;
 
@@ -134,7 +134,7 @@ public sealed class DashboardRestEndpointsTests
     [Fact]
     public async Task Cancel_Returns422_ForDispatchedMessage()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         await store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
         var id = store.AllEntries()[0].Id;
         await store.MarkSucceededAsync(id, CancellationToken.None);
@@ -153,7 +153,7 @@ public sealed class DashboardRestEndpointsTests
     [Fact]
     public async Task ForceDispatch_Returns204_ForPendingMessage()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         await store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
         var id = store.AllEntries()[0].Id;
         await store.MarkFailedAsync(id, 1, DateTimeOffset.UtcNow.AddHours(1), CancellationToken.None);
@@ -175,7 +175,7 @@ public sealed class DashboardRestEndpointsTests
     [Fact]
     public async Task ForceDispatch_Returns422_ForDispatchedMessage()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         await store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
         var id = store.AllEntries()[0].Id;
         await store.MarkSucceededAsync(id, CancellationToken.None);
@@ -194,7 +194,7 @@ public sealed class DashboardRestEndpointsTests
     [Fact]
     public async Task Requeue_PublishesMessageRequeuedEvent()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         await store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
         var id = store.AllEntries()[0].Id;
         await store.MarkFailedAsync(id, 3, DateTimeOffset.UtcNow, CancellationToken.None);
@@ -236,7 +236,7 @@ public sealed class DashboardRestEndpointsTests
     [Fact]
     public async Task Cancel_PublishesMessageCancelledEvent()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         await store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
         var id = store.AllEntries()[0].Id;
 

--- a/tests/ZeroAlloc.Outbox.Tests/EfCoreDashboardStoreTests.cs
+++ b/tests/ZeroAlloc.Outbox.Tests/EfCoreDashboardStoreTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using ZeroAlloc.Outbox;
 using ZeroAlloc.Outbox.EfCore;
 
 namespace ZeroAlloc.Outbox.Tests;
@@ -47,7 +48,7 @@ public sealed class EfCoreDashboardStoreTests : IAsyncLifetime
     public async Task GetSnapshotAsync_RetryCountGreaterThanZero_GoesToRetryQueue()
     {
         await _store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
-        var id = await _db.OutboxMessages.Select(m => m.Id).FirstAsync();
+        var id = new OutboxMessageId(await _db.OutboxMessages.Select(m => m.Id).FirstAsync());
         await _store.MarkFailedAsync(id, 2, DateTimeOffset.UtcNow.AddMinutes(5), CancellationToken.None);
 
         IOutboxDashboardStore dash = _store;
@@ -62,13 +63,14 @@ public sealed class EfCoreDashboardStoreTests : IAsyncLifetime
     public async Task RequeueAsync_ResetsDeadLetteredMessageToPending()
     {
         await _store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
-        var id = await _db.OutboxMessages.Select(m => m.Id).FirstAsync();
+        var rawId = await _db.OutboxMessages.Select(m => m.Id).FirstAsync();
+        var id = new OutboxMessageId(rawId);
         await _store.DeadLetterAsync(id, "err", CancellationToken.None);
 
         IOutboxDashboardStore dash = _store;
         await dash.RequeueAsync(id, CancellationToken.None);
 
-        var row = await _db.OutboxMessages.FindAsync([id], CancellationToken.None);
+        var row = await _db.OutboxMessages.FindAsync([rawId], CancellationToken.None);
         Assert.NotNull(row);
         Assert.Equal(OutboxMessageStatus.Pending, row!.Status);
         Assert.Equal(0, row.RetryCount);
@@ -79,7 +81,7 @@ public sealed class EfCoreDashboardStoreTests : IAsyncLifetime
     public async Task RequeueAsync_ThrowsWhenNotDeadLettered()
     {
         await _store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
-        var id = await _db.OutboxMessages.Select(m => m.Id).FirstAsync();
+        var id = new OutboxMessageId(await _db.OutboxMessages.Select(m => m.Id).FirstAsync());
 
         IOutboxDashboardStore dash = _store;
         await Assert.ThrowsAsync<InvalidOperationException>(
@@ -90,19 +92,20 @@ public sealed class EfCoreDashboardStoreTests : IAsyncLifetime
     public async Task CancelAsync_DeletesPendingRow()
     {
         await _store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
-        var id = await _db.OutboxMessages.Select(m => m.Id).FirstAsync();
+        var rawId = await _db.OutboxMessages.Select(m => m.Id).FirstAsync();
+        var id = new OutboxMessageId(rawId);
 
         IOutboxDashboardStore dash = _store;
         await dash.CancelAsync(id, CancellationToken.None);
 
-        Assert.Null(await _db.OutboxMessages.FindAsync([id], CancellationToken.None));
+        Assert.Null(await _db.OutboxMessages.FindAsync([rawId], CancellationToken.None));
     }
 
     [Fact]
     public async Task CancelAsync_ThrowsForDispatched()
     {
         await _store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
-        var id = await _db.OutboxMessages.Select(m => m.Id).FirstAsync();
+        var id = new OutboxMessageId(await _db.OutboxMessages.Select(m => m.Id).FirstAsync());
         await _store.MarkSucceededAsync(id, CancellationToken.None);
 
         IOutboxDashboardStore dash = _store;
@@ -114,7 +117,7 @@ public sealed class EfCoreDashboardStoreTests : IAsyncLifetime
     public async Task CancelAsync_ThrowsForDeadLettered()
     {
         await _store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
-        var id = await _db.OutboxMessages.Select(m => m.Id).FirstAsync();
+        var id = new OutboxMessageId(await _db.OutboxMessages.Select(m => m.Id).FirstAsync());
         await _store.DeadLetterAsync(id, "x", CancellationToken.None);
 
         IOutboxDashboardStore dash = _store;
@@ -132,7 +135,7 @@ public sealed class EfCoreDashboardStoreTests : IAsyncLifetime
 
         var before = DateTimeOffset.UtcNow;
         IOutboxDashboardStore dash = _store;
-        await dash.ForceDispatchAsync(row.Id, CancellationToken.None);
+        await dash.ForceDispatchAsync(new OutboxMessageId(row.Id), CancellationToken.None);
 
         var updated = await _db.OutboxMessages.FindAsync([row.Id], CancellationToken.None);
         Assert.NotNull(updated);
@@ -145,9 +148,9 @@ public sealed class EfCoreDashboardStoreTests : IAsyncLifetime
         for (var i = 0; i < 5; i++)
             await _store.EnqueueAsync("T", new byte[] { (byte)i }, null, CancellationToken.None);
 
-        var ids = await _db.OutboxMessages.Select(m => m.Id).ToArrayAsync();
-        foreach (var id in ids)
-            await _store.MarkSucceededAsync(id, CancellationToken.None);
+        var rawIds = await _db.OutboxMessages.Select(m => m.Id).ToArrayAsync();
+        foreach (var rawId in rawIds)
+            await _store.MarkSucceededAsync(new OutboxMessageId(rawId), CancellationToken.None);
 
         IOutboxDashboardStore dash = _store;
         var snap = await dash.GetSnapshotAsync(dispatchedLimit: 2, CancellationToken.None);
@@ -159,7 +162,7 @@ public sealed class EfCoreDashboardStoreTests : IAsyncLifetime
     public async Task ForceDispatchAsync_ThrowsForDispatched()
     {
         await _store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
-        var id = await _db.OutboxMessages.Select(m => m.Id).FirstAsync();
+        var id = new OutboxMessageId(await _db.OutboxMessages.Select(m => m.Id).FirstAsync());
         await _store.MarkSucceededAsync(id, CancellationToken.None);
 
         IOutboxDashboardStore dash = _store;
@@ -171,7 +174,7 @@ public sealed class EfCoreDashboardStoreTests : IAsyncLifetime
     public async Task GetThroughputAsync_YieldsBucketsWithinWindow()
     {
         await _store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
-        var id = await _db.OutboxMessages.Select(m => m.Id).FirstAsync();
+        var id = new OutboxMessageId(await _db.OutboxMessages.Select(m => m.Id).FirstAsync());
         await _store.MarkSucceededAsync(id, CancellationToken.None);
 
         IOutboxDashboardStore dash = _store;

--- a/tests/ZeroAlloc.Outbox.Tests/InMemoryDashboardStoreTests.cs
+++ b/tests/ZeroAlloc.Outbox.Tests/InMemoryDashboardStoreTests.cs
@@ -7,7 +7,7 @@ public class InMemoryDashboardStoreTests
     [Fact]
     public async Task GetSnapshotAsync_GroupsPendingMessages()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         await store.EnqueueAsync("T1", new byte[] { 1 }, null, CancellationToken.None);
         await store.EnqueueAsync("T2", new byte[] { 2 }, null, CancellationToken.None);
 
@@ -23,7 +23,7 @@ public class InMemoryDashboardStoreTests
     [Fact]
     public async Task GetSnapshotAsync_MovesRetryCountGreaterThanZeroToRetryQueue()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         await store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
         var id = store.AllEntries()[0].Id;
         await store.MarkFailedAsync(id, retryCount: 2, nextRetryAt: DateTimeOffset.UtcNow.AddMinutes(5), CancellationToken.None);
@@ -39,7 +39,7 @@ public class InMemoryDashboardStoreTests
     [Fact]
     public async Task GetSnapshotAsync_CapsDispatchedAtLimit()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         for (int i = 0; i < 5; i++)
         {
             await store.EnqueueAsync($"T{i}", new byte[] { (byte)i }, null, CancellationToken.None);
@@ -58,7 +58,7 @@ public class InMemoryDashboardStoreTests
     [Fact]
     public async Task RequeueAsync_MovesDeadLetterBackToPending_ResetsRetryCount()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         await store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
         var id = store.AllEntries()[0].Id;
         await store.MarkFailedAsync(id, 3, DateTimeOffset.UtcNow, CancellationToken.None);
@@ -76,7 +76,7 @@ public class InMemoryDashboardStoreTests
     [Fact]
     public async Task RequeueAsync_ThrowsWhenNotDeadLettered()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         await store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
         var id = store.AllEntries()[0].Id;
 
@@ -88,7 +88,7 @@ public class InMemoryDashboardStoreTests
     [Fact]
     public async Task CancelAsync_RemovesPendingMessage()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         await store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
         var id = store.AllEntries()[0].Id;
 
@@ -101,7 +101,7 @@ public class InMemoryDashboardStoreTests
     [Fact]
     public async Task CancelAsync_ThrowsForDispatched()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         await store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
         var id = store.AllEntries()[0].Id;
         await store.MarkSucceededAsync(id, CancellationToken.None);
@@ -114,7 +114,7 @@ public class InMemoryDashboardStoreTests
     [Fact]
     public async Task CancelAsync_ThrowsForDeadLettered()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         await store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
         var id = store.AllEntries()[0].Id;
         await store.DeadLetterAsync(id, "x", CancellationToken.None);
@@ -127,7 +127,7 @@ public class InMemoryDashboardStoreTests
     [Fact]
     public async Task ForceDispatchAsync_SetsNextRetryToNow()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         await store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
         var id = store.AllEntries()[0].Id;
         await store.MarkFailedAsync(id, 1, DateTimeOffset.UtcNow.AddHours(1), CancellationToken.None);
@@ -142,7 +142,7 @@ public class InMemoryDashboardStoreTests
     [Fact]
     public async Task ForceDispatchAsync_ThrowsForDispatched()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         await store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
         var id = store.AllEntries()[0].Id;
         await store.MarkSucceededAsync(id, CancellationToken.None);
@@ -155,7 +155,7 @@ public class InMemoryDashboardStoreTests
     [Fact]
     public async Task GetThroughputAsync_YieldsBucketsWithinWindow()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         await store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
         var id = store.AllEntries()[0].Id;
         await store.MarkSucceededAsync(id, CancellationToken.None);

--- a/tests/ZeroAlloc.Outbox.Tests/InMemoryOutboxStoreTests.cs
+++ b/tests/ZeroAlloc.Outbox.Tests/InMemoryOutboxStoreTests.cs
@@ -2,9 +2,11 @@ using ZeroAlloc.Outbox.InMemory;
 
 namespace ZeroAlloc.Outbox.Tests;
 
-public sealed class InMemoryOutboxStoreTests
+public sealed class InMemoryOutboxStoreTests : IDisposable
 {
     private readonly InMemoryOutboxStore _store = new();
+
+    public void Dispose() => _store.Dispose();
 
     [Fact]
     public async Task Enqueue_ThenFetch_ReturnsPendingEntry()

--- a/tests/ZeroAlloc.Outbox.Tests/MapOutboxDashboardTests.cs
+++ b/tests/ZeroAlloc.Outbox.Tests/MapOutboxDashboardTests.cs
@@ -13,7 +13,7 @@ public class MapOutboxDashboardTests
     [Fact]
     public async Task RootRoute_Returns200_WithHtmlBody()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         using var host = await new HostBuilder()
             .ConfigureWebHost(webBuilder =>
             {

--- a/tests/ZeroAlloc.Outbox.Tests/OutboxDashboardStoreInterfaceTests.cs
+++ b/tests/ZeroAlloc.Outbox.Tests/OutboxDashboardStoreInterfaceTests.cs
@@ -15,9 +15,9 @@ public class OutboxDashboardStoreInterfaceTests
         Assert.Empty(snapshot.DeadLettered);
         Assert.Empty(snapshot.Dispatched);
 
-        await store.RequeueAsync(Guid.NewGuid(), default);
-        await store.CancelAsync(Guid.NewGuid(), default);
-        await store.ForceDispatchAsync(Guid.NewGuid(), default);
+        await store.RequeueAsync(OutboxMessageId.New(), default);
+        await store.CancelAsync(OutboxMessageId.New(), default);
+        await store.ForceDispatchAsync(OutboxMessageId.New(), default);
 
         var points = new List<ThroughputPoint>();
         await foreach (var point in store.GetThroughputAsync(TimeSpan.FromMinutes(5), default))
@@ -44,10 +44,10 @@ public class OutboxDashboardStoreInterfaceTests
             yield break;
         }
 
-        public ValueTask RequeueAsync(Guid id, CancellationToken ct) => ValueTask.CompletedTask;
+        public ValueTask RequeueAsync(OutboxMessageId id, CancellationToken ct) => ValueTask.CompletedTask;
 
-        public ValueTask CancelAsync(Guid id, CancellationToken ct) => ValueTask.CompletedTask;
+        public ValueTask CancelAsync(OutboxMessageId id, CancellationToken ct) => ValueTask.CompletedTask;
 
-        public ValueTask ForceDispatchAsync(Guid id, CancellationToken ct) => ValueTask.CompletedTask;
+        public ValueTask ForceDispatchAsync(OutboxMessageId id, CancellationToken ct) => ValueTask.CompletedTask;
     }
 }

--- a/tests/ZeroAlloc.Outbox.Tests/OutboxSnapshotTests.cs
+++ b/tests/ZeroAlloc.Outbox.Tests/OutboxSnapshotTests.cs
@@ -6,7 +6,7 @@ public class OutboxSnapshotTests
     public void OutboxMessageView_WithIdenticalFields_AreEqual()
     {
         var created = DateTimeOffset.UtcNow;
-        var id = Guid.NewGuid();
+        var id = OutboxMessageId.New();
         var a = new OutboxMessageView
         {
             Id = id,
@@ -35,7 +35,7 @@ public class OutboxSnapshotTests
         var created = DateTimeOffset.UtcNow;
         var a = new OutboxMessageView
         {
-            Id = Guid.NewGuid(),
+            Id = OutboxMessageId.New(),
             TypeName = "T",
             CreatedAt = created,
             RetryCount = 0,
@@ -44,7 +44,7 @@ public class OutboxSnapshotTests
         };
         var b = new OutboxMessageView
         {
-            Id = Guid.NewGuid(),
+            Id = OutboxMessageId.New(),
             TypeName = "T",
             CreatedAt = created,
             RetryCount = 0,
@@ -59,7 +59,7 @@ public class OutboxSnapshotTests
     {
         var view = new OutboxMessageView
         {
-            Id = Guid.NewGuid(),
+            Id = OutboxMessageId.New(),
             TypeName = "T",
             CreatedAt = DateTimeOffset.UtcNow,
             RetryCount = 0,
@@ -75,7 +75,7 @@ public class OutboxSnapshotTests
     {
         var original = new OutboxMessageView
         {
-            Id = Guid.NewGuid(),
+            Id = OutboxMessageId.New(),
             TypeName = "T",
             CreatedAt = DateTimeOffset.UtcNow,
             RetryCount = 0,

--- a/tests/ZeroAlloc.Outbox.Tests/SseEventsEndpointTests.cs
+++ b/tests/ZeroAlloc.Outbox.Tests/SseEventsEndpointTests.cs
@@ -16,7 +16,7 @@ public sealed class SseEventsEndpointTests
     [Fact]
     public async Task Sse_Emits_EventFrame_WhenEventPublished()
     {
-        var store = new InMemoryOutboxStore();
+        using var store = new InMemoryOutboxStore();
         using var host = await CreateHostAsync(store);
         using var client = host.GetTestClient();
 
@@ -37,7 +37,7 @@ public sealed class SseEventsEndpointTests
                 try
                 {
                     await publisher.PublishAsync(
-                        new MessageDispatchedEvent(Guid.NewGuid(), DateTimeOffset.UtcNow, 1),
+                        new MessageDispatchedEvent(OutboxMessageId.New(), DateTimeOffset.UtcNow, 1),
                         cts.Token).ConfigureAwait(false);
                     await Task.Delay(50, cts.Token).ConfigureAwait(false);
                 }


### PR DESCRIPTION
## Summary

- Add `ActivitySource` span + counters + duration histogram to `OutboxWorkerService`
- Replace raw `Guid` with typed `OutboxMessageId` across all `IOutboxStore` boundaries
- Wire `ZeroAlloc.Mediator` and `ZeroAlloc.Resilience` as NuGet dependencies
- Replace all cross-repo `ProjectReference` entries with `PackageReference`

## Test plan
- [ ] `dotnet build` in a clean checkout — resolves via NuGet
- [ ] All tests pass: `dotnet test`
- [ ] Telemetry: verify `outbox.dispatch_duration_ms` is recorded on both success and failure paths
- [ ] `OutboxMessageId.New()` generates ULID-ordered IDs

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)