### PR TITLE
fix: use collection expressions, drop redundant using System

### DIFF
--- a/benchmarks/ZeroAlloc.Outbox.Benchmarks/WriteAsyncBenchmark.cs
+++ b/benchmarks/ZeroAlloc.Outbox.Benchmarks/WriteAsyncBenchmark.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Diagnostics.CodeAnalysis;
@@ -48,7 +47,7 @@ internal sealed class FakeStore : IOutboxStore
         return ValueTask.CompletedTask;
     }
     public ValueTask<IReadOnlyList<OutboxEntry>> FetchPendingAsync(int batchSize, CancellationToken ct)
-        => ValueTask.FromResult<IReadOnlyList<OutboxEntry>>(Array.Empty<OutboxEntry>());
+        => ValueTask.FromResult<IReadOnlyList<OutboxEntry>>([]);
     public ValueTask MarkSucceededAsync(OutboxMessageId id, CancellationToken ct) => ValueTask.CompletedTask;
     public ValueTask MarkFailedAsync(OutboxMessageId id, int retryCount, DateTimeOffset nextRetryAt, CancellationToken ct) => ValueTask.CompletedTask;
     public ValueTask DeadLetterAsync(OutboxMessageId id, string error, CancellationToken ct) => ValueTask.CompletedTask;

--- a/samples/ZeroAlloc.Outbox.AotSmoke/FakeOutboxStore.cs
+++ b/samples/ZeroAlloc.Outbox.AotSmoke/FakeOutboxStore.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Threading;
@@ -20,7 +19,7 @@ internal sealed class FakeOutboxStore : IOutboxStore
     }
 
     public ValueTask<IReadOnlyList<OutboxEntry>> FetchPendingAsync(int batchSize, CancellationToken ct)
-        => ValueTask.FromResult<IReadOnlyList<OutboxEntry>>(Array.Empty<OutboxEntry>());
+        => ValueTask.FromResult<IReadOnlyList<OutboxEntry>>([]);
 
     public ValueTask MarkSucceededAsync(OutboxMessageId id, CancellationToken ct) => ValueTask.CompletedTask;
     public ValueTask MarkFailedAsync(OutboxMessageId id, int retryCount, DateTimeOffset nextRetryAt, CancellationToken ct) => ValueTask.CompletedTask;


### PR DESCRIPTION
Drop unused `using System;` from benchmark and AotSmoke fake store by replacing `Array.Empty<OutboxEntry>()` with C# 12 collection expression `[]`.

Closes #27