### PR TITLE
feat(outbox.telemetry): bridge package wiring [Instrument] proxy on IOutboxTypeDispatcher (#21)

### DIFF
--- a/ZeroAlloc.Outbox.slnx
+++ b/ZeroAlloc.Outbox.slnx
@@ -8,6 +8,7 @@
     <Project Path="src/ZeroAlloc.Outbox.Dashboard.Blazor/ZeroAlloc.Outbox.Dashboard.Blazor.csproj" />
     <Project Path="src/ZeroAlloc.Outbox.Mediator/ZeroAlloc.Outbox.Mediator.csproj" />
     <Project Path="src/ZeroAlloc.Outbox.Resilience/ZeroAlloc.Outbox.Resilience.csproj" />
+    <Project Path="src/ZeroAlloc.Outbox.Telemetry/ZeroAlloc.Outbox.Telemetry.csproj" />
   </Folder>
   <Folder Name="/benchmarks/">
     <Project Path="benchmarks/ZeroAlloc.Outbox.Benchmarks/ZeroAlloc.Outbox.Benchmarks.csproj" />

--- a/ZeroAlloc.Outbox.slnx
+++ b/ZeroAlloc.Outbox.slnx
@@ -21,5 +21,6 @@
     <Project Path="tests/ZeroAlloc.Outbox.Tests/ZeroAlloc.Outbox.Tests.csproj" />
     <Project Path="tests/ZeroAlloc.Outbox.Mediator.Tests/ZeroAlloc.Outbox.Mediator.Tests.csproj" />
     <Project Path="tests/ZeroAlloc.Outbox.Resilience.Tests/ZeroAlloc.Outbox.Resilience.Tests.csproj" />
+    <Project Path="tests/ZeroAlloc.Outbox.Telemetry.Tests/ZeroAlloc.Outbox.Telemetry.Tests.csproj" />
   </Folder>
 </Solution>

--- a/docs/cookbook/08-telemetry.md
+++ b/docs/cookbook/08-telemetry.md
@@ -1,0 +1,43 @@
+---
+id: 08-telemetry
+title: OpenTelemetry integration
+sidebar_position: 8
+---
+
+# OpenTelemetry integration
+
+The `ZeroAlloc.Outbox.Telemetry` bridge package wires source-generated OpenTelemetry instrumentation into the outbox dispatch pipeline. One fluent call:
+
+```csharp
+services.AddOutbox()
+        .WithEfCore<AppDbContext>()
+        .AddOrderPlacedOutbox()
+        .WithTelemetry();
+```
+
+Every registered `IOutboxTypeDispatcher` is wrapped in a generated proxy that emits:
+
+- **Span** `outbox.dispatch` per call (ActivitySource: `ZeroAlloc.Outbox`)
+- **Counter** `outbox.dispatched_total`
+- **Histogram** `outbox.dispatch_duration_ms`
+
+`WithTelemetry()` is idempotent — calling it twice does not double-wrap.
+
+## Subscribing in OTel
+
+```csharp
+services.AddOpenTelemetry()
+        .WithTracing(t => t.AddSource("ZeroAlloc.Outbox"))
+        .WithMetrics(m => m.AddMeter("ZeroAlloc.Outbox"));
+```
+
+## Composition with WithResilience
+
+Recommended order: telemetry **outermost** (so spans capture retries), resilience inner.
+
+```csharp
+services.AddOutbox()
+        .AddOrderPlacedOutbox()
+        .WithResilience<OrderPlaced, IResilientOrderPlacedDispatcher, ResilientOrderPlacedDispatcherProxy>()
+        .WithTelemetry();
+```

--- a/docs/dependency-injection.md
+++ b/docs/dependency-injection.md
@@ -99,3 +99,7 @@ The `IOutboxTypeDispatcher` is registered as `Transient` so it is resolved fresh
 - `IOutboxStore` implementations must be **Scoped** (EF Core) or **Singleton** (InMemory). Do not register a Singleton EF Core store — it captures the `DbContext` and causes data corruption.
 - `IOutboxDispatcher<T>` implementations can be any lifetime. `Transient` is the safest default.
 - The worker creates a new `IServiceScope` per batch cycle, so Scoped services are correctly isolated.
+
+## `WithTelemetry`
+
+The `ZeroAlloc.Outbox.Telemetry` bridge package adds a parameterless `WithTelemetry()` extension on `IOutboxBuilder` that decorates every registered `IOutboxTypeDispatcher` with a source-generated OpenTelemetry proxy — emitting an `outbox.dispatch` span, an `outbox.dispatched_total` counter, and an `outbox.dispatch_duration_ms` histogram on the `ZeroAlloc.Outbox` ActivitySource/Meter. The call is idempotent and walks the entire dispatcher fan-out, so it covers all `[OutboxMessage]` types registered before the call. See the [OpenTelemetry Integration](cookbook/08-telemetry.md) cookbook entry for a full walk-through, including composition order with `WithResilience`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,3 +29,4 @@ Source-generated transactional outbox for .NET. Annotate a message type with `[O
   - [Testing with Host](cookbook/05-testing-with-host.md)
   - [AOT-Safe Serialisation](cookbook/06-aot-serialisation.md)
   - [Resilience Bridge](cookbook/07-resilience-bridge.md)
+  - [OpenTelemetry Integration](cookbook/08-telemetry.md)

--- a/src/ZeroAlloc.Outbox.Telemetry/IOutboxDispatcherTelemetry.cs
+++ b/src/ZeroAlloc.Outbox.Telemetry/IOutboxDispatcherTelemetry.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ZeroAlloc.Telemetry;
+
+namespace ZeroAlloc.Outbox.Telemetry;
+
+/// <summary>
+/// Marker interface picked up by ZeroAlloc.Telemetry's [Instrument] source generator.
+/// The generator emits <c>OutboxDispatcherTelemetryInstrumented</c> implementing this
+/// interface; the proxy wraps an instance and records spans, counters, and histograms
+/// on every <see cref="DispatchAsync"/> call.
+/// </summary>
+/// <remarks>
+/// This interface intentionally does NOT inherit from <c>IOutboxTypeDispatcher</c> — the
+/// source generator only walks members declared directly on the [Instrument] interface,
+/// so an inheriting design produced an incomplete proxy (missing TypeName) and a ctor
+/// that wouldn't accept the foundational dispatcher type. A small adapter (in this
+/// package, written in Task 1.4) bridges the generated proxy back to <c>IOutboxTypeDispatcher</c>.
+/// </remarks>
+[Instrument("ZeroAlloc.Outbox")]
+public interface IOutboxDispatcherTelemetry
+{
+    [Trace("outbox.dispatch")]
+    [Count("outbox.dispatched_total")]
+    [Histogram("outbox.dispatch_duration_ms")]
+    ValueTask DispatchAsync(ReadOnlyMemory<byte> payload, CancellationToken ct);
+}

--- a/src/ZeroAlloc.Outbox.Telemetry/InstrumentedOutboxDispatcher.cs
+++ b/src/ZeroAlloc.Outbox.Telemetry/InstrumentedOutboxDispatcher.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ZeroAlloc.Outbox;
+
+namespace ZeroAlloc.Outbox.Telemetry;
+
+/// <summary>
+/// Bridges the source-generated <see cref="OutboxDispatcherTelemetryInstrumented"/> proxy
+/// (which implements <see cref="IOutboxDispatcherTelemetry"/>) back to the foundational
+/// <see cref="IOutboxTypeDispatcher"/> contract that the Outbox worker resolves.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The adapter implements both interfaces using explicit interface implementations so
+/// callers cast to whichever interface they need. The flow per dispatch:
+/// </para>
+/// <list type="number">
+///   <item><description>Worker calls <see cref="IOutboxTypeDispatcher.DispatchAsync"/> on the adapter.</description></item>
+///   <item><description>Adapter forwards to <see cref="OutboxDispatcherTelemetryInstrumented.DispatchAsync"/> (records spans/counters/histograms).</description></item>
+///   <item><description>Proxy invokes <see cref="IOutboxDispatcherTelemetry.DispatchAsync"/> back on the adapter.</description></item>
+///   <item><description>Adapter forwards to the actual inner <see cref="IOutboxTypeDispatcher.DispatchAsync"/>.</description></item>
+/// </list>
+/// </remarks>
+internal sealed class InstrumentedOutboxDispatcher : IOutboxTypeDispatcher, IOutboxDispatcherTelemetry
+{
+    private readonly IOutboxTypeDispatcher _inner;
+    private readonly OutboxDispatcherTelemetryInstrumented _proxy;
+
+    public InstrumentedOutboxDispatcher(IOutboxTypeDispatcher inner)
+    {
+        _inner = inner;
+        // The proxy wraps `this` (which exposes IOutboxDispatcherTelemetry by forwarding to _inner).
+        _proxy = new OutboxDispatcherTelemetryInstrumented(this);
+    }
+
+    // IOutboxTypeDispatcher.TypeName: forward to inner dispatcher.
+    public string TypeName => _inner.TypeName;
+
+    // IOutboxTypeDispatcher.DispatchAsync: route through the proxy (which records spans/counters/histograms).
+    ValueTask IOutboxTypeDispatcher.DispatchAsync(ReadOnlyMemory<byte> payload, CancellationToken ct)
+        => _proxy.DispatchAsync(payload, ct);
+
+    // IOutboxDispatcherTelemetry.DispatchAsync: invoked by the proxy → calls the actual inner dispatcher.
+    ValueTask IOutboxDispatcherTelemetry.DispatchAsync(ReadOnlyMemory<byte> payload, CancellationToken ct)
+        => _inner.DispatchAsync(payload, ct);
+}

--- a/src/ZeroAlloc.Outbox.Telemetry/OutboxTelemetryBuilderExtensions.cs
+++ b/src/ZeroAlloc.Outbox.Telemetry/OutboxTelemetryBuilderExtensions.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using ZeroAlloc.Outbox;
+
+namespace ZeroAlloc.Outbox.Telemetry;
+
+/// <summary>
+/// Fluent extensions on <see cref="IOutboxBuilder"/> that wire ZeroAlloc.Telemetry
+/// instrumentation into every registered <see cref="IOutboxTypeDispatcher"/>.
+/// </summary>
+public static class OutboxTelemetryBuilderExtensions
+{
+    /// <summary>
+    /// Decorates every registered <see cref="IOutboxTypeDispatcher"/> with a source-generated
+    /// OpenTelemetry proxy. Spans, counters, and histograms are emitted on
+    /// <see cref="IOutboxTypeDispatcher.DispatchAsync"/>. ActivitySource: "ZeroAlloc.Outbox".
+    /// Safe to call multiple times — already-decorated dispatchers are skipped.
+    /// </summary>
+    public static IOutboxBuilder WithTelemetry(this IOutboxBuilder builder)
+    {
+        var services = builder.Services;
+        // Idempotence sentinel — once we've decorated, don't decorate again.
+        if (services.Any(d => d.ServiceType == typeof(OutboxTelemetryMarker))) return builder;
+        services.AddSingleton<OutboxTelemetryMarker>();
+
+        for (int i = 0; i < services.Count; i++)
+        {
+            var d = services[i];
+            if (d.ServiceType != typeof(IOutboxTypeDispatcher)) continue;
+
+            var captured = d;
+            services[i] = ServiceDescriptor.Describe(
+                typeof(IOutboxTypeDispatcher),
+                sp =>
+                {
+                    var inner = (IOutboxTypeDispatcher)CreateFromDescriptor(captured, sp);
+                    return new InstrumentedOutboxDispatcher(inner);
+                },
+                captured.Lifetime);
+        }
+        return builder;
+    }
+
+    private static object CreateFromDescriptor(ServiceDescriptor d, IServiceProvider sp)
+    {
+        if (d.ImplementationInstance is not null) return d.ImplementationInstance;
+        if (d.ImplementationFactory is not null) return d.ImplementationFactory(sp);
+        return ActivatorUtilities.CreateInstance(sp, d.ImplementationType!);
+    }
+
+    /// <summary>Marker singleton used to make <see cref="WithTelemetry"/> idempotent.</summary>
+    private sealed class OutboxTelemetryMarker { }
+}

--- a/src/ZeroAlloc.Outbox.Telemetry/ZeroAlloc.Outbox.Telemetry.csproj
+++ b/src/ZeroAlloc.Outbox.Telemetry/ZeroAlloc.Outbox.Telemetry.csproj
@@ -5,6 +5,10 @@
     <Description>ZeroAlloc.Telemetry bridge for ZeroAlloc.Outbox — wraps IOutboxTypeDispatcher with a source-generated OpenTelemetry proxy.</Description>
     <Version>0.0.0-local</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\generated</CompilerGeneratedFilesOutputPath>
+    <!-- EPC12 (ErrorProne.NET) flags ZeroAlloc.Telemetry's generated catch block where only _ex.Message is observed; that is the intended pattern for OTel ActivityStatusCode.Error and is not actionable in source-generated code. -->
+    <NoWarn>$(NoWarn);EPC12</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ZeroAlloc.Telemetry" Version="1.1.0" />

--- a/src/ZeroAlloc.Outbox.Telemetry/ZeroAlloc.Outbox.Telemetry.csproj
+++ b/src/ZeroAlloc.Outbox.Telemetry/ZeroAlloc.Outbox.Telemetry.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <PackageId>ZeroAlloc.Outbox.Telemetry</PackageId>
+    <Description>ZeroAlloc.Telemetry bridge for ZeroAlloc.Outbox — wraps IOutboxTypeDispatcher with a source-generated OpenTelemetry proxy.</Description>
+    <Version>0.0.0-local</Version>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="ZeroAlloc.Telemetry" Version="1.1.0" />
+    <!-- Pinned to 10.0.0 to match ZeroAlloc.Outbox's transitive minimum (Outbox#17) -->
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <ProjectReference Include="..\ZeroAlloc.Outbox\ZeroAlloc.Outbox.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/ZeroAlloc.Outbox.Telemetry.Tests/OutboxTelemetryTests.cs
+++ b/tests/ZeroAlloc.Outbox.Telemetry.Tests/OutboxTelemetryTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using ZeroAlloc.Outbox;
+
+namespace ZeroAlloc.Outbox.Telemetry.Tests;
+
+public class OutboxTelemetryTests
+{
+    [Fact]
+    public async Task WithTelemetry_HotPathCall_StartsActivity()
+    {
+        using var listener = new TestActivityListener("ZeroAlloc.Outbox");
+        var fake = new FakeDispatcher();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var builder = services.AddOutbox();
+        builder.Services.AddTransient<IOutboxTypeDispatcher>(_ => fake);
+        builder.WithTelemetry();
+
+        var sp = services.BuildServiceProvider();
+        var dispatcher = sp.GetServices<IOutboxTypeDispatcher>().First();
+
+        await dispatcher.DispatchAsync(ReadOnlyMemory<byte>.Empty, CancellationToken.None);
+
+        listener.StoppedActivities.Should().ContainSingle();
+        listener.StoppedActivities[0].DisplayName.Should().Be("outbox.dispatch");
+    }
+
+    private sealed class FakeDispatcher : IOutboxTypeDispatcher
+    {
+        public string TypeName => "Fake";
+        public ValueTask DispatchAsync(ReadOnlyMemory<byte> payload, CancellationToken ct) => default;
+    }
+}

--- a/tests/ZeroAlloc.Outbox.Telemetry.Tests/OutboxTelemetryTests.cs
+++ b/tests/ZeroAlloc.Outbox.Telemetry.Tests/OutboxTelemetryTests.cs
@@ -54,6 +54,45 @@ public class OutboxTelemetryTests
         listener.StoppedActivities[0].Status.Should().Be(ActivityStatusCode.Error);
     }
 
+    [Fact]
+    public async Task WithTelemetry_RecordsCounterAndHistogram()
+    {
+        long counterValue = 0;
+        double histogramValue = 0;
+
+        using var meterListener = new System.Diagnostics.Metrics.MeterListener();
+        meterListener.InstrumentPublished = (instrument, l) =>
+        {
+            if (string.Equals(instrument.Meter.Name, "ZeroAlloc.Outbox", StringComparison.Ordinal))
+                l.EnableMeasurementEvents(instrument);
+        };
+        meterListener.SetMeasurementEventCallback<long>((inst, m, _, _) =>
+        {
+            if (string.Equals(inst.Name, "outbox.dispatched_total", StringComparison.Ordinal))
+                Interlocked.Add(ref counterValue, m);
+        });
+        meterListener.SetMeasurementEventCallback<double>((inst, m, _, _) =>
+        {
+            if (string.Equals(inst.Name, "outbox.dispatch_duration_ms", StringComparison.Ordinal))
+                histogramValue = m;
+        });
+        meterListener.Start();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var builder = services.AddOutbox();
+        builder.Services.AddTransient<IOutboxTypeDispatcher>(_ => new FakeDispatcher());
+        builder.WithTelemetry();
+
+        var sp = services.BuildServiceProvider();
+        var dispatcher = sp.GetServices<IOutboxTypeDispatcher>().First();
+
+        await dispatcher.DispatchAsync(ReadOnlyMemory<byte>.Empty, CancellationToken.None);
+
+        counterValue.Should().Be(1);
+        histogramValue.Should().BeGreaterThanOrEqualTo(0); // duration in ms; may be 0 on a no-op call
+    }
+
     private sealed class FakeDispatcher : IOutboxTypeDispatcher
     {
         public string TypeName => "Fake";

--- a/tests/ZeroAlloc.Outbox.Telemetry.Tests/OutboxTelemetryTests.cs
+++ b/tests/ZeroAlloc.Outbox.Telemetry.Tests/OutboxTelemetryTests.cs
@@ -32,9 +32,38 @@ public class OutboxTelemetryTests
         listener.StoppedActivities[0].DisplayName.Should().Be("outbox.dispatch");
     }
 
+    [Fact]
+    public async Task WithTelemetry_InnerThrows_RecordsErrorStatus()
+    {
+        using var listener = new TestActivityListener("ZeroAlloc.Outbox");
+        var fake = new ThrowingDispatcher();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var builder = services.AddOutbox();
+        builder.Services.AddTransient<IOutboxTypeDispatcher>(_ => fake);
+        builder.WithTelemetry();
+
+        var sp = services.BuildServiceProvider();
+        var dispatcher = sp.GetServices<IOutboxTypeDispatcher>().First();
+
+        Func<Task> act = async () => await dispatcher.DispatchAsync(ReadOnlyMemory<byte>.Empty, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        listener.StoppedActivities.Should().ContainSingle();
+        listener.StoppedActivities[0].Status.Should().Be(ActivityStatusCode.Error);
+    }
+
     private sealed class FakeDispatcher : IOutboxTypeDispatcher
     {
         public string TypeName => "Fake";
         public ValueTask DispatchAsync(ReadOnlyMemory<byte> payload, CancellationToken ct) => default;
+    }
+
+    private sealed class ThrowingDispatcher : IOutboxTypeDispatcher
+    {
+        public string TypeName => "Throwing";
+        public ValueTask DispatchAsync(ReadOnlyMemory<byte> payload, CancellationToken ct)
+            => throw new InvalidOperationException("boom");
     }
 }

--- a/tests/ZeroAlloc.Outbox.Telemetry.Tests/OutboxTelemetryTests.cs
+++ b/tests/ZeroAlloc.Outbox.Telemetry.Tests/OutboxTelemetryTests.cs
@@ -93,6 +93,27 @@ public class OutboxTelemetryTests
         histogramValue.Should().BeGreaterThanOrEqualTo(0); // duration in ms; may be 0 on a no-op call
     }
 
+    [Fact]
+    public async Task WithTelemetry_TwoCalls_DoesNotDoubleWrap()
+    {
+        using var listener = new TestActivityListener("ZeroAlloc.Outbox");
+        var fake = new FakeDispatcher();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var builder = services.AddOutbox();
+        builder.Services.AddTransient<IOutboxTypeDispatcher>(_ => fake);
+        builder.WithTelemetry().WithTelemetry();   // call twice
+
+        var sp = services.BuildServiceProvider();
+        var dispatcher = sp.GetServices<IOutboxTypeDispatcher>().First();
+
+        await dispatcher.DispatchAsync(ReadOnlyMemory<byte>.Empty, CancellationToken.None);
+
+        // Single span — not two nested spans from a doubly-wrapped proxy.
+        listener.StoppedActivities.Should().ContainSingle();
+    }
+
     private sealed class FakeDispatcher : IOutboxTypeDispatcher
     {
         public string TypeName => "Fake";

--- a/tests/ZeroAlloc.Outbox.Telemetry.Tests/OutboxTelemetryTests.cs
+++ b/tests/ZeroAlloc.Outbox.Telemetry.Tests/OutboxTelemetryTests.cs
@@ -114,6 +114,29 @@ public class OutboxTelemetryTests
         listener.StoppedActivities.Should().ContainSingle();
     }
 
+    [Fact]
+    public async Task WithTelemetry_MultipleDispatchers_AllWrapped()
+    {
+        using var listener = new TestActivityListener("ZeroAlloc.Outbox");
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var builder = services.AddOutbox();
+        // Two distinct dispatcher registrations, mimicking what AddXxxOutbox() does per message type.
+        builder.Services.AddTransient<IOutboxTypeDispatcher>(_ => new FakeDispatcher());
+        builder.Services.AddTransient<IOutboxTypeDispatcher>(_ => new FakeDispatcher());
+        builder.WithTelemetry();
+
+        var sp = services.BuildServiceProvider();
+        var dispatchers = sp.GetServices<IOutboxTypeDispatcher>().ToList();
+
+        foreach (var d in dispatchers)
+            await d.DispatchAsync(ReadOnlyMemory<byte>.Empty, CancellationToken.None);
+
+        // Each dispatcher starts one span — both should have been wrapped.
+        listener.StoppedActivities.Should().HaveCount(2);
+    }
+
     private sealed class FakeDispatcher : IOutboxTypeDispatcher
     {
         public string TypeName => "Fake";

--- a/tests/ZeroAlloc.Outbox.Telemetry.Tests/TestActivityListener.cs
+++ b/tests/ZeroAlloc.Outbox.Telemetry.Tests/TestActivityListener.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace ZeroAlloc.Outbox.Telemetry.Tests;
+
+internal sealed class TestActivityListener : IDisposable
+{
+    private readonly ActivityListener _listener;
+    public List<Activity> StoppedActivities { get; } = new();
+
+    public TestActivityListener(string sourceName)
+    {
+        _listener = new ActivityListener
+        {
+            ShouldListenTo = src => string.Equals(src.Name, sourceName, StringComparison.Ordinal),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStopped = StoppedActivities.Add,
+        };
+        ActivitySource.AddActivityListener(_listener);
+    }
+
+    public void Dispose() => _listener.Dispose();
+}

--- a/tests/ZeroAlloc.Outbox.Telemetry.Tests/ZeroAlloc.Outbox.Telemetry.Tests.csproj
+++ b/tests/ZeroAlloc.Outbox.Telemetry.Tests/ZeroAlloc.Outbox.Telemetry.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <!-- Repo-wide TreatWarningsAsErrors with custom DiagnosticIds; keep silent for the back-compat tests. -->
+    <NoWarn>$(NoWarn);EPC12</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ZeroAlloc.Outbox.Telemetry\ZeroAlloc.Outbox.Telemetry.csproj" />
+    <ProjectReference Include="..\..\src\ZeroAlloc.Outbox\ZeroAlloc.Outbox.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+    <Using Include="FluentAssertions" />
+  </ItemGroup>
+</Project>

--- a/tests/ZeroAlloc.Outbox.Telemetry.Tests/ZeroAlloc.Outbox.Telemetry.Tests.csproj
+++ b/tests/ZeroAlloc.Outbox.Telemetry.Tests/ZeroAlloc.Outbox.Telemetry.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <!-- Repo-wide TreatWarningsAsErrors with custom DiagnosticIds; keep silent for the back-compat tests. -->
-    <NoWarn>$(NoWarn);EPC12;MA0004</NoWarn>
+    <NoWarn>$(NoWarn);EPC12;MA0004;HLQ012</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/tests/ZeroAlloc.Outbox.Telemetry.Tests/ZeroAlloc.Outbox.Telemetry.Tests.csproj
+++ b/tests/ZeroAlloc.Outbox.Telemetry.Tests/ZeroAlloc.Outbox.Telemetry.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <!-- Repo-wide TreatWarningsAsErrors with custom DiagnosticIds; keep silent for the back-compat tests. -->
-    <NoWarn>$(NoWarn);EPC12</NoWarn>
+    <NoWarn>$(NoWarn);EPC12;MA0004</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/tests/ZeroAlloc.Outbox.Telemetry.Tests/ZeroAlloc.Outbox.Telemetry.Tests.csproj
+++ b/tests/ZeroAlloc.Outbox.Telemetry.Tests/ZeroAlloc.Outbox.Telemetry.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ZeroAlloc.Outbox.Telemetry\ZeroAlloc.Outbox.Telemetry.csproj" />


### PR DESCRIPTION
Closes #21.

## Summary
New `ZeroAlloc.Outbox.Telemetry` bridge package. `services.AddOutbox().WithTelemetry()` decorates every registered `IOutboxTypeDispatcher` with a source-generated OpenTelemetry proxy. Spans, counters, histograms always emitted; subscribe by `ActivitySource`/`Meter` name in your OTel pipeline.

```csharp
services.AddOutbox()
        .WithEfCore<AppDbContext>()
        .AddOrderPlacedOutbox()
        .WithTelemetry();

services.AddOpenTelemetry()
        .WithTracing(t => t.AddSource("ZeroAlloc.Outbox"))
        .WithMetrics(m => m.AddMeter("ZeroAlloc.Outbox"));
```

## Design notes
- `IOutboxDispatcherTelemetry` is **standalone** (does not inherit `IOutboxTypeDispatcher`). The `[Instrument]` source generator only walks members declared directly on the target interface, so an inheriting design produced an incomplete proxy. A small `InstrumentedOutboxDispatcher` adapter bridges the proxy back to `IOutboxTypeDispatcher` via explicit interface implementations.
- `WithTelemetry()` is **idempotent** — uses a sentinel marker so a second call is a no-op.
- The Outbox worker resolves `IEnumerable<IOutboxTypeDispatcher>` (one per `[OutboxMessage]` type, transient). The DI extension walks the descriptor list and decorates every match.

## Test plan
- [x] HotPathCall_StartsActivity — `outbox.dispatch` activity emitted
- [x] InnerThrows_RecordsErrorStatus — `ActivityStatusCode.Error` set
- [x] RecordsCounterAndHistogram — `MeterListener` observes `outbox.dispatched_total` += 1 and `outbox.dispatch_duration_ms` records
- [x] TwoCalls_DoesNotDoubleWrap — idempotence
- [x] MultipleDispatchers_AllWrapped — fan-out
- [x] AOT IL analysis clean (no IL2026/IL3050)
- [x] 105/105 tests passing across all 5 Outbox test projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)