### PR TITLE
feat(outbox.efcore): finish OutboxMessageId migration on EF Core entity (#22)

### DIFF
--- a/src/ZeroAlloc.Outbox.EfCore/EfCoreOutboxStore.cs
+++ b/src/ZeroAlloc.Outbox.EfCore/EfCoreOutboxStore.cs
@@ -54,7 +54,7 @@ public sealed class EfCoreOutboxStore<TContext> : IOutboxStore, IOutboxDashboard
         {
             result.Add(new OutboxEntry
             {
-                Id = new OutboxMessageId(row.Id),
+                Id = row.Id,
                 TypeName = row.TypeName,
                 RawPayload = row.Payload,
                 RetryCount = row.RetryCount,
@@ -67,7 +67,7 @@ public sealed class EfCoreOutboxStore<TContext> : IOutboxStore, IOutboxDashboard
     public async ValueTask MarkSucceededAsync(OutboxMessageId id, CancellationToken ct)
     {
         var entity = await _db.Set<OutboxMessageEntity>()
-            .FindAsync(new object[] { id.Value }, ct).ConfigureAwait(false);
+            .FindAsync(new object[] { id }, ct).ConfigureAwait(false);
         if (entity is null) return;
         var fsm = new OutboxMessageFsm(ToState(entity.Status, entity.RetryCount));
         if (!fsm.TryFire(OutboxMessageTrigger.Dispatch))
@@ -81,7 +81,7 @@ public sealed class EfCoreOutboxStore<TContext> : IOutboxStore, IOutboxDashboard
     public async ValueTask MarkFailedAsync(OutboxMessageId id, int retryCount, DateTimeOffset nextRetryAt, CancellationToken ct)
     {
         var entity = await _db.Set<OutboxMessageEntity>()
-            .FindAsync(new object[] { id.Value }, ct).ConfigureAwait(false);
+            .FindAsync(new object[] { id }, ct).ConfigureAwait(false);
         if (entity is null) return;
         var fsm = new OutboxMessageFsm(ToState(entity.Status, entity.RetryCount));
         if (!fsm.TryFire(OutboxMessageTrigger.Fail))
@@ -96,7 +96,7 @@ public sealed class EfCoreOutboxStore<TContext> : IOutboxStore, IOutboxDashboard
     public async ValueTask DeadLetterAsync(OutboxMessageId id, string error, CancellationToken ct)
     {
         var entity = await _db.Set<OutboxMessageEntity>()
-            .FindAsync(new object[] { id.Value }, ct).ConfigureAwait(false);
+            .FindAsync(new object[] { id }, ct).ConfigureAwait(false);
         if (entity is null) return;
         var fsm = new OutboxMessageFsm(ToState(entity.Status, entity.RetryCount));
         if (!fsm.TryFire(OutboxMessageTrigger.Exhaust))
@@ -244,7 +244,7 @@ public sealed class EfCoreOutboxStore<TContext> : IOutboxStore, IOutboxDashboard
     public async ValueTask RequeueAsync(OutboxMessageId id, CancellationToken ct)
     {
         var entity = await _db.Set<OutboxMessageEntity>()
-            .FindAsync(new object[] { id.Value }, ct).ConfigureAwait(false)
+            .FindAsync(new object[] { id }, ct).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"Message {id} not found.");
         var fsm = new OutboxMessageFsm(ToState(entity.Status, entity.RetryCount));
         if (!fsm.TryFire(OutboxMessageTrigger.Requeue))
@@ -261,7 +261,7 @@ public sealed class EfCoreOutboxStore<TContext> : IOutboxStore, IOutboxDashboard
     public async ValueTask CancelAsync(OutboxMessageId id, CancellationToken ct)
     {
         var entity = await _db.Set<OutboxMessageEntity>()
-            .FindAsync(new object[] { id.Value }, ct).ConfigureAwait(false)
+            .FindAsync(new object[] { id }, ct).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"Message {id} not found.");
         var fsm = new OutboxMessageFsm(ToState(entity.Status, entity.RetryCount));
         if (!fsm.TryFire(OutboxMessageTrigger.Cancel))
@@ -274,7 +274,7 @@ public sealed class EfCoreOutboxStore<TContext> : IOutboxStore, IOutboxDashboard
     public async ValueTask ForceDispatchAsync(OutboxMessageId id, CancellationToken ct)
     {
         var entity = await _db.Set<OutboxMessageEntity>()
-            .FindAsync(new object[] { id.Value }, ct).ConfigureAwait(false)
+            .FindAsync(new object[] { id }, ct).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"Message {id} not found.");
         if (entity.Status != OutboxMessageStatus.Pending)
             throw new InvalidOperationException($"Message {id} is not pending (status: {entity.Status}).");
@@ -294,7 +294,7 @@ public sealed class EfCoreOutboxStore<TContext> : IOutboxStore, IOutboxDashboard
 
     private static OutboxMessageView ToView(in RawProjection r) => new()
     {
-        Id = new OutboxMessageId(r.Id),
+        Id = r.Id,
         TypeName = r.TypeName,
         CreatedAt = r.CreatedAt,
         RetryCount = r.RetryCount,
@@ -311,7 +311,7 @@ public sealed class EfCoreOutboxStore<TContext> : IOutboxStore, IOutboxDashboard
 
     private sealed class RawProjection
     {
-        public Guid Id { get; set; }
+        public OutboxMessageId Id { get; set; }
         public string TypeName { get; set; } = string.Empty;
         public DateTimeOffset CreatedAt { get; set; }
         public int RetryCount { get; set; }

--- a/src/ZeroAlloc.Outbox.EfCore/OutboxDbContextExtensions.cs
+++ b/src/ZeroAlloc.Outbox.EfCore/OutboxDbContextExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using ZeroAlloc.ValueObjects.EfCore;
 
 namespace ZeroAlloc.Outbox.EfCore;
 
@@ -16,6 +17,13 @@ public static class OutboxDbContextExtensions
         modelBuilder.Entity<OutboxMessageEntity>(entity =>
         {
             entity.HasKey(e => e.Id);
+            // Map OutboxMessageId <-> Guid via the ZeroAlloc.ValueObjects.EfCore converter.
+            // The convention-based registration (Properties<TId>().HaveConversion) lives on
+            // ModelConfigurationBuilder (i.e. DbContext.ConfigureConventions), which is not
+            // available here; per-property HasConversion keeps the registration local to
+            // AddOutboxMessages so consumers don't have to override ConfigureConventions.
+            entity.Property(e => e.Id)
+                  .HasConversion<TypedIdValueConverter<OutboxMessageId, Guid>>();
             entity.Property(e => e.TypeName).HasMaxLength(256).IsRequired();
             entity.HasIndex(e => new { e.Status, e.NextRetryAt })
                   .HasDatabaseName("IX_OutboxMessages_Status_NextRetryAt");

--- a/src/ZeroAlloc.Outbox.EfCore/OutboxMessageEntity.cs
+++ b/src/ZeroAlloc.Outbox.EfCore/OutboxMessageEntity.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using ZeroAlloc.Outbox;
 
 namespace ZeroAlloc.Outbox.EfCore;
 
@@ -10,7 +11,7 @@ namespace ZeroAlloc.Outbox.EfCore;
 public sealed class OutboxMessageEntity
 {
     [Key]
-    public Guid Id { get; set; } = Guid.NewGuid();
+    public OutboxMessageId Id { get; set; } = OutboxMessageId.New();
 
     [Required, MaxLength(256)]
     public string TypeName { get; set; } = string.Empty;

--- a/src/ZeroAlloc.Outbox.EfCore/ZeroAlloc.Outbox.EfCore.csproj
+++ b/src/ZeroAlloc.Outbox.EfCore/ZeroAlloc.Outbox.EfCore.csproj
@@ -6,15 +6,14 @@
     <Version>0.0.0-local</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.15" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.15" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
+  <ItemGroup>
+    <!-- ZeroAlloc.ValueObjects.EfCore 1.3.1 requires EF Core 9.0.0+ across all TFMs.
+         EF Core 9.0.x supports net8.0 (LTS), so we unify on 9.0.4 for all targets. -->
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ZeroAlloc.Outbox\ZeroAlloc.Outbox.csproj" />
+    <PackageReference Include="ZeroAlloc.ValueObjects.EfCore" Version="1.3.1" />
   </ItemGroup>
 </Project>

--- a/tests/ZeroAlloc.Outbox.Tests/EfCoreDashboardStoreTests.cs
+++ b/tests/ZeroAlloc.Outbox.Tests/EfCoreDashboardStoreTests.cs
@@ -48,7 +48,7 @@ public sealed class EfCoreDashboardStoreTests : IAsyncLifetime
     public async Task GetSnapshotAsync_RetryCountGreaterThanZero_GoesToRetryQueue()
     {
         await _store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
-        var id = new OutboxMessageId(await _db.OutboxMessages.Select(m => m.Id).FirstAsync());
+        var id = await _db.OutboxMessages.Select(m => m.Id).FirstAsync();
         await _store.MarkFailedAsync(id, 2, DateTimeOffset.UtcNow.AddMinutes(5), CancellationToken.None);
 
         IOutboxDashboardStore dash = _store;
@@ -64,7 +64,7 @@ public sealed class EfCoreDashboardStoreTests : IAsyncLifetime
     {
         await _store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
         var rawId = await _db.OutboxMessages.Select(m => m.Id).FirstAsync();
-        var id = new OutboxMessageId(rawId);
+        var id = rawId;
         await _store.DeadLetterAsync(id, "err", CancellationToken.None);
 
         IOutboxDashboardStore dash = _store;
@@ -81,7 +81,7 @@ public sealed class EfCoreDashboardStoreTests : IAsyncLifetime
     public async Task RequeueAsync_ThrowsWhenNotDeadLettered()
     {
         await _store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
-        var id = new OutboxMessageId(await _db.OutboxMessages.Select(m => m.Id).FirstAsync());
+        var id = await _db.OutboxMessages.Select(m => m.Id).FirstAsync();
 
         IOutboxDashboardStore dash = _store;
         await Assert.ThrowsAsync<InvalidOperationException>(
@@ -93,7 +93,7 @@ public sealed class EfCoreDashboardStoreTests : IAsyncLifetime
     {
         await _store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
         var rawId = await _db.OutboxMessages.Select(m => m.Id).FirstAsync();
-        var id = new OutboxMessageId(rawId);
+        var id = rawId;
 
         IOutboxDashboardStore dash = _store;
         await dash.CancelAsync(id, CancellationToken.None);
@@ -105,7 +105,7 @@ public sealed class EfCoreDashboardStoreTests : IAsyncLifetime
     public async Task CancelAsync_ThrowsForDispatched()
     {
         await _store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
-        var id = new OutboxMessageId(await _db.OutboxMessages.Select(m => m.Id).FirstAsync());
+        var id = await _db.OutboxMessages.Select(m => m.Id).FirstAsync();
         await _store.MarkSucceededAsync(id, CancellationToken.None);
 
         IOutboxDashboardStore dash = _store;
@@ -117,7 +117,7 @@ public sealed class EfCoreDashboardStoreTests : IAsyncLifetime
     public async Task CancelAsync_ThrowsForDeadLettered()
     {
         await _store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
-        var id = new OutboxMessageId(await _db.OutboxMessages.Select(m => m.Id).FirstAsync());
+        var id = await _db.OutboxMessages.Select(m => m.Id).FirstAsync();
         await _store.DeadLetterAsync(id, "x", CancellationToken.None);
 
         IOutboxDashboardStore dash = _store;
@@ -135,7 +135,7 @@ public sealed class EfCoreDashboardStoreTests : IAsyncLifetime
 
         var before = DateTimeOffset.UtcNow;
         IOutboxDashboardStore dash = _store;
-        await dash.ForceDispatchAsync(new OutboxMessageId(row.Id), CancellationToken.None);
+        await dash.ForceDispatchAsync(row.Id, CancellationToken.None);
 
         var updated = await _db.OutboxMessages.FindAsync([row.Id], CancellationToken.None);
         Assert.NotNull(updated);
@@ -150,7 +150,7 @@ public sealed class EfCoreDashboardStoreTests : IAsyncLifetime
 
         var rawIds = await _db.OutboxMessages.Select(m => m.Id).ToArrayAsync();
         foreach (var rawId in rawIds)
-            await _store.MarkSucceededAsync(new OutboxMessageId(rawId), CancellationToken.None);
+            await _store.MarkSucceededAsync(rawId, CancellationToken.None);
 
         IOutboxDashboardStore dash = _store;
         var snap = await dash.GetSnapshotAsync(dispatchedLimit: 2, CancellationToken.None);
@@ -162,7 +162,7 @@ public sealed class EfCoreDashboardStoreTests : IAsyncLifetime
     public async Task ForceDispatchAsync_ThrowsForDispatched()
     {
         await _store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
-        var id = new OutboxMessageId(await _db.OutboxMessages.Select(m => m.Id).FirstAsync());
+        var id = await _db.OutboxMessages.Select(m => m.Id).FirstAsync();
         await _store.MarkSucceededAsync(id, CancellationToken.None);
 
         IOutboxDashboardStore dash = _store;
@@ -174,7 +174,7 @@ public sealed class EfCoreDashboardStoreTests : IAsyncLifetime
     public async Task GetThroughputAsync_YieldsBucketsWithinWindow()
     {
         await _store.EnqueueAsync("T", new byte[] { 1 }, null, CancellationToken.None);
-        var id = new OutboxMessageId(await _db.OutboxMessages.Select(m => m.Id).FirstAsync());
+        var id = await _db.OutboxMessages.Select(m => m.Id).FirstAsync();
         await _store.MarkSucceededAsync(id, CancellationToken.None);
 
         IOutboxDashboardStore dash = _store;

--- a/tests/ZeroAlloc.Outbox.Tests/TypedIdValueConverterTests.cs
+++ b/tests/ZeroAlloc.Outbox.Tests/TypedIdValueConverterTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using ZeroAlloc.Outbox.EfCore;
+
+namespace ZeroAlloc.Outbox.Tests;
+
+/// <summary>
+/// Verifies that <see cref="OutboxMessageEntity.Id"/> survives a write/read round-trip
+/// through the <c>TypedIdValueConverter&lt;OutboxMessageId, Guid&gt;</c> registered by
+/// <see cref="OutboxDbContextExtensions.AddOutboxMessages"/>.
+/// </summary>
+public sealed class TypedIdValueConverterTests : IAsyncLifetime
+{
+    private SqliteConnection _conn = default!;
+    private DashboardTestDbContext _db = default!;
+
+    public async Task InitializeAsync()
+    {
+        _conn = new SqliteConnection("DataSource=:memory:");
+        await _conn.OpenAsync(CancellationToken.None).ConfigureAwait(false);
+        var opts = new DbContextOptionsBuilder<DashboardTestDbContext>()
+            .UseSqlite(_conn)
+            .Options;
+        _db = new DashboardTestDbContext(opts);
+        await _db.Database.EnsureCreatedAsync(CancellationToken.None).ConfigureAwait(false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _db.DisposeAsync().ConfigureAwait(false);
+        await _conn.DisposeAsync().ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task EntityRoundTrip_PreservesOutboxMessageId()
+    {
+        var id = OutboxMessageId.New();
+        _db.Set<OutboxMessageEntity>().Add(new OutboxMessageEntity
+        {
+            Id = id,
+            TypeName = "Test",
+            Payload = new byte[] { 0x01 },
+        });
+        await _db.SaveChangesAsync(CancellationToken.None);
+        _db.ChangeTracker.Clear();
+
+        var roundTripped = await _db.Set<OutboxMessageEntity>()
+            .Where(e => e.Id == id)
+            .FirstAsync(CancellationToken.None);
+
+        roundTripped.Id.Should().Be(id);
+    }
+}


### PR DESCRIPTION
Closes #22.

## Summary
Closes the last raw-`Guid` boundary in the Outbox migration. `OutboxMessageEntity.Id` is now `OutboxMessageId` (the existing `[TypedId]` wrapper), with a value converter registered inline at the entity level. Column type stays `uniqueidentifier`/`BLOB(16)`; no EF migration required.

## Changes
- `OutboxMessageEntity.Id`: `Guid` → `OutboxMessageId` (default factory: `OutboxMessageId.New()`)
- `AddOutboxMessages()`: registers `entity.Property(e => e.Id).HasConversion<TypedIdValueConverter<OutboxMessageId, Guid>>()` inline (the `Properties<T>()` API lives on `ModelConfigurationBuilder` not `ModelBuilder`, so per-property is the right fit — and consumers don't need to override `ConfigureConventions`)
- `EfCoreOutboxStore.cs`: dropped redundant `new OutboxMessageId(row.Id)` wrappers in projections; `FindAsync` calls now pass the typed id directly (converter handles boxing)
- 10 mechanical adjustments in `tests/ZeroAlloc.Outbox.Tests/EfCoreDashboardStoreTests.cs` removing redundant `new OutboxMessageId(...)` constructions
- New test: `TypedIdValueConverterTests.cs` proves the converter round-trip preserves the id

## Build / package note
`ZeroAlloc.ValueObjects.EfCore 1.3.1`'s `net8.0` dep group requires `Microsoft.EntityFrameworkCore >= 9.0.0`. To resolve NU1605, EF Core was unified to `9.0.4` across all TFMs in `ZeroAlloc.Outbox.EfCore`. EF Core 9.x supports `net8.0` LTS so consumers on .NET 8 are unaffected at the runtime level — but anyone explicitly pinning EF Core 8.x in their own consumer project will now hit a downgrade error and must bump.

## Test plan
- [x] `dotnet test` green: 106 / 106 passed (baseline 105 + 1 new round-trip test)
- [x] EF round-trip test (insert → save → requery → assert equality) passes
- [x] No EF migration emitted (column type unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)