### PR TITLE
ci(release): publish Outbox bridge packages to NuGet

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -46,6 +46,11 @@ jobs:
           dotnet pack src/ZeroAlloc.Outbox.Generator/ZeroAlloc.Outbox.Generator.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
           dotnet pack src/ZeroAlloc.Outbox.EfCore/ZeroAlloc.Outbox.EfCore.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
           dotnet pack src/ZeroAlloc.Outbox.InMemory/ZeroAlloc.Outbox.InMemory.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
+          dotnet pack src/ZeroAlloc.Outbox.Mediator/ZeroAlloc.Outbox.Mediator.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
+          dotnet pack src/ZeroAlloc.Outbox.Resilience/ZeroAlloc.Outbox.Resilience.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
+          dotnet pack src/ZeroAlloc.Outbox.Telemetry/ZeroAlloc.Outbox.Telemetry.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
+          dotnet pack src/ZeroAlloc.Outbox.Dashboard/ZeroAlloc.Outbox.Dashboard.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
+          dotnet pack src/ZeroAlloc.Outbox.Dashboard.Blazor/ZeroAlloc.Outbox.Dashboard.Blazor.csproj -c Release --no-build -p:PackageVersion=${{ needs.release-please.outputs.version }} -o ./nupkg
 
       - name: Push to NuGet
         run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,11 @@ jobs:
           dotnet pack src/ZeroAlloc.Outbox.Generator/ZeroAlloc.Outbox.Generator.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
           dotnet pack src/ZeroAlloc.Outbox.EfCore/ZeroAlloc.Outbox.EfCore.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
           dotnet pack src/ZeroAlloc.Outbox.InMemory/ZeroAlloc.Outbox.InMemory.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
+          dotnet pack src/ZeroAlloc.Outbox.Mediator/ZeroAlloc.Outbox.Mediator.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
+          dotnet pack src/ZeroAlloc.Outbox.Resilience/ZeroAlloc.Outbox.Resilience.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
+          dotnet pack src/ZeroAlloc.Outbox.Telemetry/ZeroAlloc.Outbox.Telemetry.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
+          dotnet pack src/ZeroAlloc.Outbox.Dashboard/ZeroAlloc.Outbox.Dashboard.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
+          dotnet pack src/ZeroAlloc.Outbox.Dashboard.Blazor/ZeroAlloc.Outbox.Dashboard.Blazor.csproj --no-build -c Release -p:PackageVersion=${{ steps.version.outputs.version }} -o ./artifacts
 
       - name: Push to NuGet
         run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
## Summary
The release workflows previously only packed and pushed the core Outbox + Generator + EfCore + InMemory packages. The five bridge packages — Mediator, Resilience, Telemetry, Dashboard, Dashboard.Blazor — were never published to NuGet, making them effectively only usable as ProjectReferences.

This PR extends both release workflows to pack and push all 5 bridges alongside the core packages. Same fix pattern as ZeroAlloc.Mediator#54 (which addressed the analogous gap there).

## Affected packages (now publishable)
- ZeroAlloc.Outbox.Mediator
- ZeroAlloc.Outbox.Resilience
- ZeroAlloc.Outbox.Telemetry
- ZeroAlloc.Outbox.Dashboard
- ZeroAlloc.Outbox.Dashboard.Blazor

## Test plan
- [x] dotnet pack succeeds for all 5 bridges locally
- [ ] Next release-please cycle publishes all 9 packages (verify post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)