### PR TITLE
feat: bundle source generator into ZeroAlloc.Outbox package

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,18 @@ Multiple packages in this family — see [Documentation](docs/) or NuGet for the
 
 ## Install
 
+The source generator is bundled into the main package — a single `PackageReference` is all you need:
+
 ```bash
 # Core abstractions + source generator (always required)
 dotnet add package ZeroAlloc.Outbox
-dotnet add package ZeroAlloc.Outbox.Generator
 
 # Pick a store:
 dotnet add package ZeroAlloc.Outbox.EfCore    # production — Entity Framework Core
 dotnet add package ZeroAlloc.Outbox.InMemory  # testing — in-process, no database
 ```
+
+> The standalone `ZeroAlloc.Outbox.Generator` package is still published for backwards compatibility with existing direct PackageReferences, but new consumers should reference only `ZeroAlloc.Outbox`.
 
 ---
 

--- a/src/ZeroAlloc.Outbox/ZeroAlloc.Outbox.csproj
+++ b/src/ZeroAlloc.Outbox/ZeroAlloc.Outbox.csproj
@@ -26,4 +26,19 @@
     <PackageReference Include="ZeroAlloc.StateMachine" Version="1.0.1" />
     <PackageReference Include="ZeroAlloc.Serialisation" Version="2.0.0" />
   </ItemGroup>
+
+  <!--
+    Bundle the source generator into the NuGet package so consumers get it by
+    referencing only ZeroAlloc.Outbox. The standalone ZeroAlloc.Outbox.Generator
+    package is still published for backwards compatibility, but new consumers
+    should reference the main package only.
+  -->
+  <Target Name="IncludeGeneratorInPackage" BeforeTargets="_GetPackageFiles">
+    <ItemGroup>
+      <None Include="$(MSBuildThisFileDirectory)..\ZeroAlloc.Outbox.Generator\bin\$(Configuration)\netstandard2.0\ZeroAlloc.Outbox.Generator.dll"
+            Pack="true"
+            PackagePath="analyzers/dotnet/cs"
+            Visible="false" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary
Until now consumers had to install both `ZeroAlloc.Outbox` and `ZeroAlloc.Outbox.Generator` (with the right `OutputItemType` / `PrivateAssets` flags) to get a working setup. Bundling the generator DLL inside the main library's NuGet package under `analyzers/dotnet/cs/` means **a single `PackageReference` is now enough**.

`ZeroAlloc.Outbox.Generator` continues to publish as a standalone package for backwards compatibility with existing direct `PackageReference`s. New consumers should reference only `ZeroAlloc.Outbox`.

## What changes
- Add `IncludeGeneratorInPackage` MSBuild target that packs the generator DLL under `analyzers/dotnet/cs/` in the main library's nupkg

## Test plan
- [ ] CI green
- [ ] `dotnet pack` produces `ZeroAlloc.Outbox.nupkg` containing the generator DLL at `analyzers/dotnet/cs/`
- [ ] In a fresh project with only `<PackageReference Include="ZeroAlloc.Outbox">`, an `[OutboxMessage]`-attributed type produces generated writer/dispatcher code
- [ ] Existing setups with both packages referenced continue to work (Roslyn dedupes same-version analyzers)

Related: ZeroAlloc-Net/ZeroAlloc.Rest#67

🤖 Generated with [Claude Code](https://claude.com/claude-code)