### PR TITLE
fix(release-please): drop pre-major flags (package is post-1.0)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,8 +3,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [
         { "type": "feat",     "section": "Features" },
         { "type": "fix",      "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary

Removes `bump-minor-pre-major` and `bump-patch-for-minor-pre-major` from `release-please-config.json`. These flags are documented by release-please as pre-1.0 only. On a post-1.0 package they silently demote SemVer:

- `feat!:` (breaking) -> minor instead of major
- `feat:` -> patch instead of minor

## Why this is highest priority

ZeroAlloc.Outbox is currently at **2.3.0** on NuGet. The next `feat!:` commit would have cut a 2.4.0 instead of 3.0.0 - a silent SemVer violation shipped to consumers. Of the four packages with this defect, Outbox is furthest past 1.0 and therefore most exposed.

This is the same defect class fixed in ZeroAlloc.Mediator PR #65.

## Change

Two lines removed from `packages.".":`:

```diff
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
```

Everything else (release-type, changelog-sections) is preserved. JSON validated.

## Test plan

- [ ] Confirm release-please bot regenerates the release PR with correct version bump semantics on the next merge
- [ ] Verify next `feat!:` commit produces a major bump (3.0.0) and next `feat:` produces a minor bump

Generated with [Claude Code](https://claude.com/claude-code)