### PR TITLE
ci: remove auto-publish to nuget on every main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,6 @@ jobs:
           dotnet pack src/ZeroAlloc.Outbox.EfCore/ZeroAlloc.Outbox.EfCore.csproj --no-build -c Release -p:PackageVersion=${{ steps.gitversion.outputs.version }} -o ./artifacts
           dotnet pack src/ZeroAlloc.Outbox.InMemory/ZeroAlloc.Outbox.InMemory.csproj --no-build -c Release -p:PackageVersion=${{ steps.gitversion.outputs.version }} -o ./artifacts
 
-      - name: Push to NuGet (pre-release)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-
   aot-smoke:
     runs-on: ubuntu-latest
     # Publishes samples/ZeroAlloc.Outbox.AotSmoke with PublishAot=true. Exercises


### PR DESCRIPTION
## Summary
- Per org-wide decision: only release-please-shepherded releases should publish to NuGet.
- The auto-publish step was shipping the 4 sibling packages (`ZeroAlloc.Outbox`, `ZeroAlloc.Outbox.Generator`, `ZeroAlloc.Outbox.EfCore`, `ZeroAlloc.Outbox.InMemory`) on every main push outside release-please's bookkeeping.
- Build/pack steps remain so CI still validates packaging.

## Test plan
- [ ] CI green on PR (build, test, pack, aot-smoke, api-compat).
- [ ] Verify no `dotnet nuget push` runs on next merge to main.