### PR TITLE
ci: switch release-please to manifest mode

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,8 @@ jobs:
         uses: googleapis/release-please-action@v4
         id: release
         with:
-          release-type: simple
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
           token: ${{ secrets.GITHUB_TOKEN }}
 
   publish:


### PR DESCRIPTION
## Summary

Switches the `release-please` action from inline `release-type: simple` to using the checked-in `release-please-config.json` + `.release-please-manifest.json` (Pattern B). Mirrors ZeroAlloc.Mediator PR #68.

## Root cause

The action was running with `release-type: simple` set inline. In that mode `release-please-action@v4` ignores the config files entirely and tracks state from its inline defaults, which had drifted from the published NuGet version (2.3.0).

## Trifecta complete

This is the third and final release-please fix for ZeroAlloc.Outbox:

- Pattern A (auto-publish removed from ci.yml): #47
- Pattern C (pre-major flags removed from config): #45
- Pattern B (manifest mode): this PR

## Changes

- `.github/workflows/release-please.yml`: replace `release-type: simple` with `config-file:` + `manifest-file:`.

`release-please-config.json` is single-package (`.`) and already free of pre-major flags. `.release-please-manifest.json` is already `{ ".": "2.3.0" }`, aligned to the NuGet stable, so no manifest content change was needed.

## Test plan

- [ ] Merge and confirm release-please opens (or refreshes) a release PR using the config files instead of inline defaults
- [ ] Confirm next computed version is based on `2.3.0`