### PR TITLE
chore(deps): pin all floating versions + fix SQLitePCLRaw CVE

### DIFF
--- a/benchmarks/ZeroAlloc.Outbox.Benchmarks/ZeroAlloc.Outbox.Benchmarks.csproj
+++ b/benchmarks/ZeroAlloc.Outbox.Benchmarks/ZeroAlloc.Outbox.Benchmarks.csproj
@@ -12,6 +12,9 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.4" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <!-- CVE-2025-6965 / GHSA-2m69-gcr7-jv3q: pin the native SQLite binary (3.50.3) pulled
+         transitively by Microsoft.Data.Sqlite / EF Core Sqlite (2.1.x is vulnerable). -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
 
     <ProjectReference Include="..\..\src\ZeroAlloc.Outbox\ZeroAlloc.Outbox.csproj" />
     <ProjectReference Include="..\..\src\ZeroAlloc.Outbox.Generator\ZeroAlloc.Outbox.Generator.csproj"

--- a/samples/ZeroAlloc.Outbox.AotSmoke/ZeroAlloc.Outbox.AotSmoke.csproj
+++ b/samples/ZeroAlloc.Outbox.AotSmoke/ZeroAlloc.Outbox.AotSmoke.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
 
     <ProjectReference Include="..\..\src\ZeroAlloc.Outbox\ZeroAlloc.Outbox.csproj"
                       SetTargetFramework="TargetFramework=net10.0" />

--- a/tests/ZeroAlloc.Outbox.Tests/ZeroAlloc.Outbox.Tests.csproj
+++ b/tests/ZeroAlloc.Outbox.Tests/ZeroAlloc.Outbox.Tests.csproj
@@ -13,6 +13,9 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.4" />
+    <!-- CVE-2025-6965 / GHSA-2m69-gcr7-jv3q: pin the native SQLite binary (3.50.3) pulled
+         transitively by Microsoft.Data.Sqlite / EF Core Sqlite (2.1.x is vulnerable). -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.0" />
     <ProjectReference Include="..\..\src\ZeroAlloc.Outbox\ZeroAlloc.Outbox.csproj" />
     <ProjectReference Include="..\..\src\ZeroAlloc.Outbox.InMemory\ZeroAlloc.Outbox.InMemory.csproj" />


### PR DESCRIPTION
Two things, both currently red on this repo:

1. **SQLitePCLRaw CVE** (NU1903 / GHSA-2m69-gcr7-jv3q) — Microsoft.Data.Sqlite / EF Core Sqlite pull the vulnerable native lib 2.1.x transitively, failing restore under NuGetAudit. Pin `SQLitePCLRaw.lib.e_sqlite3` to **3.50.3** in the Sqlite-referencing projects (same fix already applied to ORM/EventSourcing/Templates/Saga/AdoNet).
2. **Floating versions** — pinned to resolved so an upstream half-publish can't break the build via a float.

Version-only; `dotnet build` verified locally.