### PR TITLE
fix(generator): suppress EPS06 for Roslyn 4.14's larger pipeline struct

### DIFF
--- a/src/ZeroAlloc.Outbox.Generator/OutboxGenerator.cs
+++ b/src/ZeroAlloc.Outbox.Generator/OutboxGenerator.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -6,6 +7,21 @@ namespace ZeroAlloc.Outbox.Generator;
 [Generator]
 public sealed class OutboxGenerator : IIncrementalGenerator
 {
+    // EPS06 fires on every Where/Select in an incremental pipeline as of Roslyn
+    // 4.14: IncrementalValuesProvider<T> grew from one instance field to two
+    // (8 -> 16 bytes), crossing ErrorProne's large-struct threshold. It stayed a
+    // readonly struct, so there is no defensive copy and none of the correctness
+    // risk EPS06 exists to catch - only a 16-byte copy in setup code that runs
+    // once per compilation, not per syntax node.
+    //
+    // Suppressed rather than fixed because it cannot be fixed: Where and Select
+    // are extension methods on the Roslyn API taking the provider by value, with
+    // no by-ref overload. Chaining them *is* the incremental generator pipeline.
+    // ErrorProne.NET.Structs 0.1.2 exposes no threshold setting to correct instead.
+    [SuppressMessage(
+        "ErrorProne.NET.Structs",
+        "EPS06:Hidden struct copy operation",
+        Justification = "Roslyn's own pipeline API passes the readonly 16-byte IncrementalValuesProvider by value; there is no alternative overload.")]
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var models = context.SyntaxProvider

--- a/src/ZeroAlloc.Outbox.Generator/ZeroAlloc.Outbox.Generator.csproj
+++ b/src/ZeroAlloc.Outbox.Generator/ZeroAlloc.Outbox.Generator.csproj
@@ -21,8 +21,8 @@
     <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
   </ItemGroup>
   <!--
     Pack the generator DLL under analyzers/dotnet/cs. Without this, dotnet pack falls back

--- a/src/ZeroAlloc.Outbox/ZeroAlloc.Outbox.csproj
+++ b/src/ZeroAlloc.Outbox/ZeroAlloc.Outbox.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/ZeroAlloc.Outbox.Generator.Tests/ZeroAlloc.Outbox.Generator.Tests.csproj
+++ b/tests/ZeroAlloc.Outbox.Generator.Tests/ZeroAlloc.Outbox.Generator.Tests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageReference Include="Verify.Xunit" Version="28.16.0" />
     <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.6.0" />
     <ProjectReference Include="..\..\src\ZeroAlloc.Outbox\ZeroAlloc.Outbox.csproj" />


### PR DESCRIPTION
Supersedes **#72**, which bumped the packages alone and failed to build.

## Why the bump-only PR failed

Roslyn 4.14 makes every `Where`/`Select` in an incremental pipeline report `EPS06`, and warnings are errors here:

```
error EPS06: Expression 'Select' causes a hidden copy of a struct 'IncrementalValuesProvider'
error EPS06: Expression 'Where'  causes a hidden copy of a struct 'IncrementalValuesProvider'
```

## Root cause, measured rather than inferred

Two experiments pin it down:

**1. It is Roslyn, not the analyzer.** Holding `ErrorProne.NET.Structs` 0.1.2 and `Microsoft.CodeAnalysis.Analyzers` 3.11.0 fixed and moving only `Microsoft.CodeAnalysis.CSharp` back to 4.8.0 — **builds clean**. Forward to 4.14.0 — EPS06 returns.

**2. What changed in the type.** Reflection over both shipped assemblies:

| Roslyn | `IncrementalValuesProvider<T>` | instance fields |
|---|---|---:|
| 4.8.0 | `readonly struct` | **1** |
| 4.14.0 | `readonly struct` | **2** |

It grew from 8 to 16 bytes and crossed ErrorProne's large-struct threshold. **It stayed `readonly`** — so there is no defensive copy, and none of the correctness risk EPS06 exists to catch.

## Why suppressed rather than fixed

This repo's standing preference is to fix analyzer findings, not silence them. This one cannot be fixed:

- `Where` and `Select` are **extension methods on the Roslyn API** taking the provider **by value**. There is no by-ref overload, and chaining them *is* the incremental generator pipeline — every incremental generator in existence does this.
- `ErrorProne.NET.Structs` 0.1.2 ships **no threshold setting** to correct instead (no `error_prone_*` configuration keys exist in the assembly).
- What remains is a 16-byte copy in **setup code that runs once per compilation**, not per syntax node.

So the suppression is scoped to the methods that own a pipeline, with the measurement recorded at the call site — not a blanket `severity = none` in `.editorconfig`.

## Verification

Release build (what CI runs) and the full suite, on this branch:

- **0 warnings / 0 errors**
- **109 tests pass** — 88 core, 7 generator, plus Mediator/Resilience/Telemetry suites. None adjusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
