### PR TITLE
chore(deps): replace FluentAssertions with AwesomeAssertions

### DIFF
--- a/tests/ZeroAlloc.Outbox.Generator.Tests/ZeroAlloc.Outbox.Generator.Tests.csproj
+++ b/tests/ZeroAlloc.Outbox.Generator.Tests/ZeroAlloc.Outbox.Generator.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Verify.SourceGenerators" Version="2.5.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageReference Include="Verify.Xunit" Version="31.12.5" />
     <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.8.10" />
@@ -17,7 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />
-    <Using Include="FluentAssertions" />
+    <Using Include="AwesomeAssertions" />
     <Using Include="VerifyXunit" />
   </ItemGroup>
 </Project>

--- a/tests/ZeroAlloc.Outbox.Mediator.Tests/ZeroAlloc.Outbox.Mediator.Tests.csproj
+++ b/tests/ZeroAlloc.Outbox.Mediator.Tests/ZeroAlloc.Outbox.Mediator.Tests.csproj
@@ -8,13 +8,13 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
     <ProjectReference Include="..\..\src\ZeroAlloc.Outbox.Mediator\ZeroAlloc.Outbox.Mediator.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />
-    <Using Include="FluentAssertions" />
+    <Using Include="AwesomeAssertions" />
   </ItemGroup>
 </Project>

--- a/tests/ZeroAlloc.Outbox.Resilience.Tests/ZeroAlloc.Outbox.Resilience.Tests.csproj
+++ b/tests/ZeroAlloc.Outbox.Resilience.Tests/ZeroAlloc.Outbox.Resilience.Tests.csproj
@@ -8,12 +8,12 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
     <ProjectReference Include="..\..\src\ZeroAlloc.Outbox.Resilience\ZeroAlloc.Outbox.Resilience.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />
-    <Using Include="FluentAssertions" />
+    <Using Include="AwesomeAssertions" />
   </ItemGroup>
 </Project>

--- a/tests/ZeroAlloc.Outbox.Telemetry.Tests/OutboxTelemetryTests.cs
+++ b/tests/ZeroAlloc.Outbox.Telemetry.Tests/OutboxTelemetryTests.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using ZeroAlloc.Outbox;
 

--- a/tests/ZeroAlloc.Outbox.Telemetry.Tests/ZeroAlloc.Outbox.Telemetry.Tests.csproj
+++ b/tests/ZeroAlloc.Outbox.Telemetry.Tests/ZeroAlloc.Outbox.Telemetry.Tests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
   </ItemGroup>
@@ -19,6 +19,6 @@
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />
-    <Using Include="FluentAssertions" />
+    <Using Include="AwesomeAssertions" />
   </ItemGroup>
 </Project>

--- a/tests/ZeroAlloc.Outbox.Tests/OutboxBuilderTests.cs
+++ b/tests/ZeroAlloc.Outbox.Tests/OutboxBuilderTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using ZeroAlloc.Outbox;

--- a/tests/ZeroAlloc.Outbox.Tests/OutboxWorkerTests.cs
+++ b/tests/ZeroAlloc.Outbox.Tests/OutboxWorkerTests.cs
@@ -95,7 +95,7 @@ public sealed class OutboxWorkerTests
 
         await host.StopAsync();
 
-        dispatchCalls.Should().BeGreaterOrEqualTo(2);
+        dispatchCalls.Should().BeGreaterThanOrEqualTo(2);
         var finalEntry = store.AllEntries().First();
         finalEntry.Status.Should().Be(InMemoryOutboxStore.InMemoryEntryStatus.DeadLetter);
     }

--- a/tests/ZeroAlloc.Outbox.Tests/TypedIdValueConverterTests.cs
+++ b/tests/ZeroAlloc.Outbox.Tests/TypedIdValueConverterTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using AwesomeAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using ZeroAlloc.Outbox.EfCore;

--- a/tests/ZeroAlloc.Outbox.Tests/ZeroAlloc.Outbox.Tests.csproj
+++ b/tests/ZeroAlloc.Outbox.Tests/ZeroAlloc.Outbox.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.18" />
     <!-- CVE-2025-6965 / GHSA-2m69-gcr7-jv3q: pin the native SQLite binary (3.50.3) pulled
@@ -25,6 +25,6 @@
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />
-    <Using Include="FluentAssertions" />
+    <Using Include="AwesomeAssertions" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Why not simply take FluentAssertions 8

FluentAssertions changed licence at v8. Read from the packages, not from memory:

| Version | `<license>` |
|---|---|
| 6.12.2 | expression — **Apache-2.0** |
| 7.2.0 | expression — **Apache-2.0** |
| **8.10.0** | file — **Xceed Community License** |

From v8's `LICENSE` file:

> Non-Commercial Use means the software is used in **open-source, personal or experimental** projects, and **"is not being used by or for an organisation … that charges fees or earns revenues"**.
>
> *"Any use outside of these parameters requires a paid Commercial License from Xceed."*

That is a licensing decision rather than a version bump — and because these are published packages, it reaches consumers too.

## AwesomeAssertions

The community fork that stayed open source. Verified from the package:

```
AwesomeAssertions 9.5.0   license expression: Apache-2.0
lib: net47, net6.0, net8.0, netstandard2.0, netstandard2.1
```

**Not a pure drop-in.** 9.x renames the root namespace — confirmed by inspecting the assembly, which exports `AwesomeAssertions.Numeric`, `AwesomeAssertions.Primitives` and `AwesomeAssertions.Execution` and contains no `FluentAssertions` namespace. So this PR moves three things together:

- `<PackageReference Include="FluentAssertions" …>` → `AwesomeAssertions` 9.5.0
- `<Using Include="FluentAssertions" />` → `AwesomeAssertions`
- `using FluentAssertions;` → `using AwesomeAssertions;`

The fork tracks the v7/v8 API, so any v6-era call sites rename with it (`BeGreaterOrEqualTo` → `BeGreaterThanOrEqualTo`).

## Verification

Clean Release build and the full suite for this repo — build **exit 0**, all test assemblies green, and **no test was adjusted** beyond the API renames noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
